### PR TITLE
Elfinder fullscreen

### DIFF
--- a/Controller/ElfinderController.php
+++ b/Controller/ElfinderController.php
@@ -11,13 +11,14 @@ class ElfinderController extends Controller
         $parameters = $this->container->getParameter('fm_elfinder');
         $editor = $parameters['editor'];
         $locale = $parameters['locale'];
+        $fullscreen = $parameters['fullscreen'];
         switch ($editor){
             // add more
             case 'ckeditor':
-                return $this->render('FMElfinderBundle:Elfinder:ckeditor.html.twig', array('locale'=>$locale));
+                return $this->render('FMElfinderBundle:Elfinder:ckeditor.html.twig', array('locale'=>$locale, 'fullscreen'=>$fullscreen));
                 break;
             default:
-                return $this->render('FMElfinderBundle:Elfinder:simple.html.twig', array('locale'=>$locale));
+                return $this->render('FMElfinderBundle:Elfinder:simple.html.twig', array('locale'=>$locale, 'fullscreen'=>$fullscreen));
         }
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,6 +31,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('locale')->defaultValue('en_US.UTF8')->end()
                 ->scalarNode('editor')->defaultValue('ckeditor')->end()
                 ->scalarNode('showhidden')->defaultValue('false')->end()
+                ->scalarNode('fullscreen')->defaultValue('true')->end()
             ->end()
         ;
 

--- a/Resources/views/Elfinder/ckeditor.html.twig
+++ b/Resources/views/Elfinder/ckeditor.html.twig
@@ -49,8 +49,18 @@
                     window.close();
                 }
             }
-        })
-    })
+        });
+
+        {% if fullscreen %}
+            var $window = $(window);
+            $window.resize(function(){
+                var win_height = $window.height();
+                if( f.height() != win_height ){
+                    f.height(win_height - 20).resize();
+                }
+            });
+        {% endif %}
+    });
 </script>
 </head>
 <body>

--- a/Resources/views/Elfinder/simple.html.twig
+++ b/Resources/views/Elfinder/simple.html.twig
@@ -28,12 +28,21 @@
     <script src="{{ asset_url }}"></script>
     {% endjavascripts %}
     <script type="text/javascript" charset="utf-8">
-
         $().ready(function() {
-            $('#elfinder').elfinder({
+            var f = $('#elfinder').elfinder({
                 url : '{{path('ef_connect')}}',
                 lang : '{{locale}}'
             });
+
+            {% if fullscreen %}
+                var $window = $(window);
+                $window.resize(function(){
+                    var win_height = $window.height();
+                    if( f.height() != win_height ){
+                        f.height(win_height - 20).resize();
+                    }
+                });
+            {% endif %}
         });
     </script>
 </head>


### PR DESCRIPTION
Add Elfinder fullscreen configuration.

With fullscreen elfinder, file browser interface looked more natural (file browser).
Elfinder will resize according to the window size (height).

Inspiration from : https://github.com/Studio-42/elFinder/issues/84
