### PR TITLE
Fixed JS throwing errors

### DIFF
--- a/Resources/views/Elfinder/tinymce.html.twig
+++ b/Resources/views/Elfinder/tinymce.html.twig
@@ -50,8 +50,7 @@
     tinyMCEPopup.onInit.add(FileBrowserDialogue.init, FileBrowserDialogue);
 
     $().ready(function() {
-
-        var f = $('#elfinder').elfinder({
+        var $f = $('#elfinder').elfinder({
             url : '{{ path('ef_connect') }}',
             lang : '{{ locale }}',
             getfile : {
@@ -60,16 +59,17 @@
                 folders : false
             },
             getFileCallback : function(url) {
-                path = '/' + url.path;
+                var path = '/' + url.path;
                 FileBrowserDialogue.mySubmit(path);
             }
-        }).elfinder('instance');
+        });
+    
         {% if fullscreen %}
         var $window = $(window);
         $window.resize(function(){
-            var $win_height = $window.height();
-            if( $f.height() != $win_height ){
-                $f.height($win_height).resize();
+            var win_height = $window.height();
+            if( $f.height() != win_height ){
+                $f.height(win_height).resize();
             }
         });
         {% endif %}


### PR DESCRIPTION
Now that the variable is passed to the view with TinyMCE, the JS is still not working.

I've fixed the JS errors but the full screen option is still not working. I really don't get the logic there.
Why set only the height and not the width? Why is it in a .resize() event?

I don't know if I should make a PR considering it's still not working but at least it fixes the bugs in the console.
