### PR TITLE
added feature to use a symfony service as a volumeDriver

### DIFF
--- a/Bridge/ElFinderBridge.php
+++ b/Bridge/ElFinderBridge.php
@@ -1,0 +1,41 @@
+<?php
+namespace FM\ElfinderBundle\Bridge;
+
+use FM\ElFinderPHP\ElFinder;
+
+/**
+ * Class ElFinderBridge
+ *
+ * Use Symfony services as regular VolumeDrivers.
+ *
+ */
+class ElFinderBridge extends ElFinder
+{
+    /**
+     * @param array $opts
+     */
+    protected function mountVolumes($opts)
+    {
+        foreach ($opts['roots'] as $i => $o) {
+            $volume = null;
+            if(isset($o['service'])){
+                $driver = $o['service'];
+                if(is_object($driver) && $driver instanceof \FM\ElFinderPHP\Driver\ElFinderVolumeDriver){
+                    $volume = $driver;
+                    unset($opts['roots'][$i]);
+                }
+            }
+
+            if ($volume && $volume->mount($o)) {
+                // unique volume id (ends on "_") - used as prefix to files hash
+                $id = $volume->id();
+
+                $this->volumes[$id] = $volume;
+                if (!$this->default && $volume->isReadable()) {
+                    $this->default = $this->volumes[$id];
+                }
+            }
+        }
+        parent::mountVolumes($opts);
+    }
+}

--- a/Loader/FMElfinderLoader.php
+++ b/Loader/FMElfinderLoader.php
@@ -2,18 +2,26 @@
 
 namespace FM\ElfinderBundle\Loader;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-
-use FM\ElFinderPHP\ElFinder;
+use Symfony\Component\HttpFoundation\Request;
 use FM\ElFinderPHP\Connector\ElFinderConnector;
-use FM\ElFinderPHP\Driver\ElFinderVolumeLocalFileSystem;
+use FM\ElfinderBundle\Bridge\ElFinderBridge;
 
 class FMElfinderLoader
 {
+    /**
+     * @var array $options
+     */
     protected $options = array();
+
+    /**
+     * @var ContainerInterface $container
+     */
     protected $container;
 
+    /**
+     * @param ContainerInterface $container
+     */
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
@@ -34,8 +42,10 @@ class FMElfinderLoader
 
         foreach ($parameters['connector']['roots'] as $parameter) {
             $path = $parameter['path'];
+            $driver = $this->container->has($parameter['driver']) ? $this->container->get($parameter['driver']) : null;
             $options['roots'][] = array(
                 'driver'        => $parameter['driver'],
+                'service'       => $driver,
                 'path'          => $path . '/',
                 'URL'           => isset($parameter['url']) && $parameter['url']
                     ? strpos($parameter['url'], 'http') === 0
@@ -57,7 +67,7 @@ class FMElfinderLoader
      */
     public function load()
     {
-        $connector = new ElFinderConnector(new ElFinder($this->options));
+        $connector = new ElFinderConnector(new ElFinderBridge($this->options));
         $connector->run();
     }
 


### PR DESCRIPTION
This will only work after https://github.com/helios-ag/ElFinderPHP/pull/2 is merged.

With this change you can use a Symfony service as a volumeDriver. 
The service should however be an instance of the FM\ElFinderPHP\Driver\ElFinderVolumeDriver class. This check is to ensure the service is a valid ElFinder VolumeDriver.

To configure a root with a service-driver you can simply use the service id as the drive key:

``` yaml
fm_elfinder:
    connector:
        roots:
            uploads:
                driver: elfinder.driver.filesystem
                path: uploads
```

This means that if you add the service definition:

``` xml
<service id="elfinder.driver.filesystem" class="FM\ElFinderPHP\Driver\ElFinderVolumeLocalFileSystem" />
```

It should work just fine. This feature does not break or change any existing logic, so using LocalFileSystem as the driver should work just as well. 
