### PR TITLE
Fix #31 Uncaught RangeError: Maximum call stack size exceeded in some browsers

### DIFF
--- a/Resources/views/Elfinder/ckeditor.html.twig
+++ b/Resources/views/Elfinder/ckeditor.html.twig
@@ -43,8 +43,8 @@
         $(window).resize(function(){
             var h = $(window).height();
 
-            if($('#elfinder').height() != h){
-                $('#elfinder').height(h).resize();
+            if($('#elfinder').height() != h - 20){
+                $('#elfinder').height(h -20).resize();
             }
         });
         {% endif %}


### PR DESCRIPTION
The original way of re-sizing the ELFinder caused in some browsers a infinite loop resulting in a Maximum call stack size exceed.

It is hard to verify what exactly wen't wrong in the original one, also it is hard to prove that this is a better solution. But it fixes the problem i was having with the old way.
