### PR TITLE
document new config options, fix ckeditor compressed template

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,11 +28,11 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('locale')->defaultNull()->end()
-                ->booleanNode('showhidden')->defaultValue(false)->end()
+                ->booleanNode('showhidden')->defaultFalse()->end()
                 ->scalarNode('editor')->defaultValue('simple')->end()
-                ->booleanNode('compression')->defaultValue(false)->end()
-                ->booleanNode('fullscreen')->defaultValue(true)->end()
-                ->booleanNode('include_assets')->defaultValue(true)->end()
+                ->booleanNode('compression')->defaultFalse()->end()
+                ->booleanNode('fullscreen')->defaultTrue()->end()
+                ->booleanNode('include_assets')->defaultTrue()->end()
                 ->scalarNode('tinymce_popup_path')->defaultValue('')->end()
             ->end()
         ;

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ fm_elfinder:
     editor: ckeditor # other choices are tinymce or simple
     showhidden: false # defaults to false
     fullscreen: true # defaults true, applies to simple and ckeditor editors
+    include_assets: true # disable if you want to handle loading of the javascript and css assets yourself
+    compression: false # enable if you configured the uglifycss and uglifyjs2 assetic filters and want compression
     connector:
         debug: false # defaults to false
         roots:       # at least one root must be defined
@@ -285,5 +287,7 @@ Manual integration guide can be found [here](/INTEGRATION_GUIDE.md)
 
 ##Changelog
 
-1.x
-Switched from YUI compressor to Uglify
+### 1.4
+
+* Made compressing assets optional. When compressing is active, it now uses
+  uglify.js instead of YUI compressor.

--- a/Resources/views/Elfinder/compressed/ckeditor.html.twig
+++ b/Resources/views/Elfinder/compressed/ckeditor.html.twig
@@ -3,12 +3,12 @@
 <head>
     <meta charset="utf-8">
         {% stylesheets output='assetic/css/compiled/fmelfinder/main.css'
-        'bundles/fmelfinder/css/*' filter='cssrewrite,?yui_css' %}
+        'bundles/fmelfinder/css/*' filter='cssrewrite,?uglifycss' %}
             <link rel="stylesheet" href="{{ asset_url }}" />
         {% endstylesheets %}
 </head>
 <body>
-        {% javascripts output='assetic/js/compiled/fmelfinder/main.js' filter='?yui_js'
+        {% javascripts output='assetic/js/compiled/fmelfinder/main.js' filter='?uglifyjs2'
             '@FMElfinderBundle/Resources/public/js/jquery/jquery-1.8.0.min.js'
             '@FMElfinderBundle/Resources/public/js/jquery/jquery-ui-1.8.23.custom.min.js'
             '@FMElfinderBundle/Resources/public/js/elfinder.min.js'
@@ -53,6 +53,3 @@
 <div id="elfinder"></div>
 </body>
 </html>
-
-
-


### PR DESCRIPTION
this is some cleanup on the Configuration class, the ckeditor compressed template was still referring to yui and the new options where not documented in the readme.

thanks a lot for this bundle, its quite useful in our project!
