### PR TITLE
Update ElFinderFile.php

### DIFF
--- a/Entity/ElFinderFile.php
+++ b/Entity/ElFinderFile.php
@@ -24,7 +24,7 @@ class ElFinderFile
     /**
      * @var string
      *
-     * @ORM\Column(name="name", type="string", length=256, nullable=false)
+     * @ORM\Column(name="name", type="string", length=255, nullable=false)
      */
     protected $name;
 
@@ -52,7 +52,7 @@ class ElFinderFile
     /**
      * @var string
      *
-     * @ORM\Column(name="mime", type="string", length=256, nullable=false)
+     * @ORM\Column(name="mime", type="string", length=255, nullable=false)
      */
     protected $mime;
 


### PR DESCRIPTION
Update varchar length for fields "name" and "mime" : 256 seems to geneate a mysql error on innodb tables when creating keys.

```
[Doctrine\DBAL\DBALException]
  An exception occurred while executing 'CREATE TABLE elfinder_file (id INT AUTO_INCREMENT NOT NULL, parent_id INT NOT NULL, name VARCHAR(256) NOT NULL, conten
  t LONGBLOB NOT NULL, size INT NOT NULL, mtime INT NOT NULL, mime VARCHAR(256) NOT NULL, `read` VARCHAR(255) NOT NULL, `write` VARCHAR(255) NOT NULL, locked V
  ARCHAR(255) NOT NULL, hidden VARCHAR(255) NOT NULL, width INT NOT NULL, height INT NOT NULL, INDEX parent_id (parent_id), UNIQUE INDEX parent_name (parent_id
  , name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB':
  SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes
```

See : http://stackoverflow.com/a/16820166
