### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,8 @@ Add FMElfinderBundle in your composer.json:
 For Symfony 2.4 and later use version 2.5
 For Symfony between 2.1 and 2.3 (2.3 included) use version ~2.3
 
-```js
-{
-    "require": {
-        "helios-ag/fm-elfinder-bundle": "~2.5"
-    }
-}
+```sh
+composer require helios-ag/fm-elfinder-bundle
 ```
 
 Now tell composer to download the bundle by running the command:


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
