### PR TITLE
Allow custom template renderer

### DIFF
--- a/Controller/ElFinderController.php
+++ b/Controller/ElFinderController.php
@@ -1,6 +1,7 @@
 <?php
 namespace FM\ElfinderBundle\Controller;
 
+use Exception;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
@@ -46,6 +47,20 @@ class ElFinderController extends Controller
         $result = array();
 
         switch ($editor) {
+            case 'custom':
+                if (empty($parameters['editor_template'])) {
+                    throw new Exception("Configuration error : 'custom' editor must define 'editor_template' parameter");
+                }
+
+                $result['template'] = $parameters['editor_template'];
+                $result['params'] = array(
+                    'locale'        => $locale,
+                    'fullscreen'    => $fullscreen,
+                    'includeAssets' => $includeAssets,
+                    'instance'      => $instance,
+                    'relative_path' => $relativePath
+                );
+                return $result;
             case 'ckeditor':
                 $result['template'] = 'FMElfinderBundle:Elfinder:ckeditor.html.twig';
                 $result['params'] = array(

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ class Configuration implements ConfigurationInterface
                         ->children()
                             ->scalarNode('locale')->defaultNull()->end()
                             ->scalarNode('editor')->defaultValue('simple')->end()
+                            ->scalarNode('editor_template')->defaultNull()->end()
                             ->booleanNode('fullscreen')->defaultTrue()->end()
                             ->booleanNode('include_assets')->defaultTrue()->end()
                             ->scalarNode('tinymce_popup_path')->defaultValue('')->end()

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ fm_elfinder:
     instances:
         default:
             locale: %locale% # defaults to current request locale
-            editor: ckeditor # other choices are tinymce or simple, and form
+            editor: ckeditor # other choices are tinymce, simple, form or custom
             fullscreen: true # defaults true, applies to simple and ckeditor editors
             include_assets: true # disable if you want to handle loading of the javascript and css assets yourself
             compression: false # enable if you configured the uglifycss and uglifyjs2 assetic filters and want compression
@@ -158,8 +158,9 @@ fm_elfinder:
 * driver - can be LocalFileSystem, FTP or MySQL2, currently supported only LocalFileSystem, default is LocalFileSystem
 * locale - locale determines, which language, ElFinder will use, to translate user interface, default is current request locale
 * editor - determines what template to render, to be compatible with WYSIWYG web editor, currently supported options are:
- "ckeditor", "tinymce" and "simple". How to configure CKEDitor and TinyMCE to work with this bundle, will be explained further in this document.
+ "ckeditor", "tinymce", "simple" and "custom". How to configure CKEDitor and TinyMCE to work with this bundle, will be explained further in this document.
  "simple" can be used as standalone filebrowser for managing and uploading files.
+* editor_template - define template to renderer editor is set to "custom".
 * showhidden - hides directories starting with . (dot)
 * connector - root node for defining options for elfinder root directiories and debug option
 * roots - define


### PR DESCRIPTION
Allow a custom template to renderer Elfinder component.

It's interesting if you use a custom WYSIWYG editor you want to integrate with this bundle.