### PR TITLE
IvoryCKEditor sample was incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,9 +338,11 @@ Note that instance name should be the same as configured in elfinder bundle
 
 $form = $this->createFormBuilder()
             ->add('content', 'ckeditor', array(
-                'filebrowser_image_browse_url' => array(
-                    'route'            => 'elfinder',
-                    'route_parameters' => array('instance' => 'ckeditor'),
+                'config' => array(
+                    'filebrowser_image_browse_url' => array(
+                        'route'            => 'elfinder',
+                        'route_parameters' => array('instance' => 'ckeditor'),
+                    ),
                 ),
             ))
             ->getForm()


### PR DESCRIPTION
Here's how it looks in the [IvoryCKEditorBundle doc](https://github.com/egeloen/IvoryCKEditorBundle/blob/master/Resources/doc/file_browse_upload.md):
```
$builder->add('field', 'ckeditor', array(
    'config' => array(
        'filebrowserBrowseRoute'           => 'my_route',
        'filebrowserBrowseRouteParameters' => array('slug' => 'my-slug'),
        'filebrowserBrowseRouteAbsolute'   => true,
    ),
));
```