### PR TITLE
Add triggering of change event

### DIFF
--- a/Resources/views/Form/elfinder_widget.html.twig
+++ b/Resources/views/Form/elfinder_widget.html.twig
@@ -6,7 +6,7 @@
                 var childWin = window.open("{{path('elfinder', {'instance': instance })}}?id={{ id }}", "popupWindow", "height=450, width=900");
             });
             function setValue(value, element_id) {
-                $('[data-type="elfinder-input-field"]' + (element_id ? '[id="'+ element_id +'"]': '')).val(value);
+                $('[data-type="elfinder-input-field"]' + (element_id ? '[id="'+ element_id +'"]': '')).val(value).change();
             }
         </script>
     {% endif %}


### PR DESCRIPTION
It will trigger `change` event when new value is set from ElFinder popup. Now this event isn't triggered, and binding of events to `input` aren't work.