### PR TITLE
Fix bug "pathPrefix" when use Form Type

### DIFF
--- a/Controller/ElFinderController.php
+++ b/Controller/ElFinderController.php
@@ -124,7 +124,8 @@ class ElFinderController extends Controller
                     'id'            => $formTypeId,
                     'relative_path' => $relativePath,
                     'prefix'        => $assetsPath,
-                    'theme'         => $theme
+                    'theme'         => $theme,
+                    'pathPrefix'    => $pathPrefix
                 );
                 return $result;
             default:


### PR DESCRIPTION
When use Elfinder as Form Type I have error: 
Variable "pathPrefix" does not exist in FMElfinderBundle:Elfinder:elfinder_type.html.twig at line 19
