### PR TITLE
Multiple thumbnails

### DIFF
--- a/Configuration/ElFinderConfigurationReader.php
+++ b/Configuration/ElFinderConfigurationReader.php
@@ -125,6 +125,17 @@ class ElFinderConfigurationReader implements ElFinderConfigurationProviderInterf
                 'archiveMimes'      => $parameter['archive_mimes'],
                 'archivers'         => $parameter['archivers']
             );
+
+            $driverOptions['additionalTmb'] = array();
+            $tmbPaths = array($parameter['tmb_path'] => true);
+            foreach ($parameter['thumbnails'] as $tmbConfigName => $tmbConfigValues) {
+                // we avoid to create different thumbnails sets on the same path
+                if (!isset($tmbPaths[$tmbConfigValues['tmb_path']])) {
+                    $driverOptions['additionalTmb'][$tmbConfigName] = $this->configureThumbnails($tmbConfigValues);
+                    $tmbPaths[$tmbConfigValues['tmb_path']] = true;
+                }
+            }
+
             if(!$parameter['show_hidden']) {
                 $driverOptions['accessControl'] = array($this, 'access');
             };
@@ -152,6 +163,23 @@ class ElFinderConfigurationReader implements ElFinderConfigurationProviderInterf
                 ? $parameter['url']
                 : sprintf('%s://%s%s/%s/%s', $request->getScheme(), $request->getHttpHost(), $request->getBasePath(), $parameter['url'], $homeFolder)
             : sprintf('%s://%s%s/%s/%s', $request->getScheme(), $request->getHttpHost(), $request->getBasePath(), $path, $homeFolder);
+    }
+
+    /**
+     * @param  array  $thumbnailsOptions
+     * @return array
+     */
+    private function configureThumbnails(array $thumbnailsOptions)
+    {
+        $thumbnailsConfig = array();
+        $thumbnailsConfig['tmbPath']     = $thumbnailsOptions['tmb_path'];
+        $thumbnailsConfig['tmbPathMode'] = $thumbnailsOptions['tmb_path_mode'];
+        $thumbnailsConfig['tmbUrl']      = $thumbnailsOptions['tmb_url'];
+        $thumbnailsConfig['tmbSize']     = $thumbnailsOptions['tmb_size'];
+        $thumbnailsConfig['tmbCrop']     = $thumbnailsOptions['tmb_crop'];
+        $thumbnailsConfig['tmbBgColor']  = $thumbnailsOptions['tmb_bg_color'];
+
+        return $thumbnailsConfig;
     }
 
     /**

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -76,6 +76,7 @@ class Configuration implements ConfigurationInterface
                                                 ->integerNode('tmb_size')->defaultValue(48)->end()
                                                 ->booleanNode('tmb_crop')->defaultTrue()->end()
                                                 ->scalarNode('tmb_bg_color')->defaultValue('#ffffff')->end()
+                                                ->append($this->createAdditionalThumbnailsNode())
                                                 ->booleanNode('copy_overwrite')->defaultTrue()->end()
                                                 ->booleanNode('copy_join')->defaultTrue()->end()
                                                 ->booleanNode('copy_from')->defaultTrue()->end()
@@ -212,6 +213,25 @@ class Configuration implements ConfigurationInterface
                 ->end();
 
         return $treeBuilder;
+    }
+
+    /**
+     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition The additional thumbnails node.
+     */
+    private function createAdditionalThumbnailsNode()
+    {
+        return $this->createNode('thumbnails')
+            ->useAttributeAsKey('name')
+            ->prototype('array')
+                ->children()
+                    ->scalarNode('tmb_path')->defaultValue('.tmb')->end()
+                    ->scalarNode('tmb_path_mode')->defaultValue(0777)->end()
+                    ->scalarNode('tmb_url')->defaultValue('')->end()
+                    ->integerNode('tmb_size')->defaultValue(48)->end()
+                    ->booleanNode('tmb_crop')->defaultTrue()->end()
+                    ->scalarNode('tmb_bg_color')->defaultValue('#ffffff')->end()
+                ->end()
+            ->end();
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Recommended bundles to use with:
     - [Step 5: Install assets](#step-5-install-assets)
 - [Basic configuration](#basic-configuration)
     - [Add configuration options to your config.yml](#add-configuration-options-to-your-configyml)
+    - [Multiple thumbnails](#multiple-thumbnails)
     - [Use multiple upload folder by instance](#use-multiple-upload-folder-by-instance)
 - [CORS support](#cors-support)
 - [Elfinder Form Type](#elfinder-form-type)
@@ -197,11 +198,41 @@ fm_elfinder:
     * upload_allow: ['image/png', 'image/jpg', 'image/jpeg'] 
     * upload_deny: ['all'] 
     * upload_max_size: 2M 
+
 You can see the full list of roots options [here](https://github.com/Studio-42/elFinder/wiki/Connector-configuration-options#root-options "connector options list"). To use them,
 convert camelCased option name to under_scored option name.
 
 **Note:** `crypt_lib` option is not available as not implemented yet by elFinder PHP library.
-    
+
+
+### Multiple thumbnails
+
+By default, elFinder creates one thumbnail by image file.
+
+You can provide other thumbnails settings (in addition of the default one who is also configurable).
+Simply add a `thumbnails` key under one of your `roots` configuration :
+
+```yml
+roots:
+    uploads:
+        thumbnails:
+            tmb_64: # name of the thumbnail settings
+                tmb_path: '.tmb64' # if you don't provide a path different from the default one ('.tmb'), your thumbnail setting won't be took
+                tmb_size: 64
+                tmb_crop: false
+                # other tmb options ...
+            tmb_128:
+                tmb_path: '.tmb128'
+                tmb_size: 128
+                tmb_crop: false
+                # other tmb options ...
+```
+The default values for additional thumbnails settings are the same as the default thumbnail setting.
+
+For now, only the default thumbnail URL is returned.
+To get additional thumbnails URL, simply replace the path of the default thumbnail
+in the default thumbnail URL by the additional thumbnails' path.
+
 ### Use multiple upload folder by instance
 
 You can set multiple upload root folder by instance configuration.

--- a/Tests/DependencyInjection/ConfigurationLoadTest.php
+++ b/Tests/DependencyInjection/ConfigurationLoadTest.php
@@ -65,6 +65,7 @@ class ConfigurationLoadTest extends AbstractExtensionConfigurationTestCase
                                 'tmb_crop' => true,
                                 'tmb_bg_color' => '#ffffff',
                                 'tmb_path_mode' => 511,
+                                'thumbnails' => array(),
                                 'copy_overwrite' => true,
                                 'copy_join' => true,
                                 'copy_from' => true,


### PR DESCRIPTION
Hi,

This PR is a tweak to create multiple thumbnails by image file instead of only one.
You can configure the additional thumbnails you want to create. See the README.md to know how.

To get the additional thumbnails URL, you've got to guess it from the default one URL by replacing default tmb path by additional tmb path.
I know it would be way better to return additional thumbnails URL in an appropriate way, but it involves a big work on the original elFinder (btw I've asked for this feature [here](https://github.com/nao-pon/elFinder/issues/13)).

The additional thumbnails creation / deletion is done by looping inside library functions who used to make and delete the default thumbnails, see at [# 18](https://github.com/helios-ag/ElFinderPHP/pull/18) PR on the lib side.

What do you think of it?