### PR TITLE
Fixed configuration loading for root parameter (ftp)

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -238,6 +238,7 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('passive')->defaultTrue()->end()
                             ->booleanNode('ssl')->defaultTrue()->end()
                             ->integerNode('timeout')->defaultValue(30)->end()
+                            ->scalarNode('root')->defaultValue('/')->end()
                     ->end()
                 ->end()
                 ->arrayNode('aws_s3_v2')


### PR DESCRIPTION
The root parameter for Flysystem/FTP was not defined in Configuration.php. Because of this, in ELFinderConfigurationReader in configureFlysystem method $opt['ftp']['root'] was not defined.