### PR TITLE
Fixed configuration loading of attributes.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -119,13 +119,15 @@ class Configuration implements ConfigurationInterface
                                                     ->defaultValue(array('read' => true, 'write' => true))
                                                 ->end() // defaults
                                                 ->arrayNode('attributes')
-                                                    ->beforeNormalization()
-                                                        ->ifTrue(function ($v) { return is_string($v); })
-                                                        ->then(function ($v) {
-                                                            return array_map('trim', explode(',', $v));
-                                                        })
+                                                    ->prototype('array')
+                                                        ->children()
+                                                            ->scalarNode('pattern')->end()
+                                                            ->scalarNode('read')->defaultValue(true)->end()
+                                                            ->scalarNode('write')->defaultValue(true)->end()
+                                                            ->scalarNode('locked')->defaultValue(false)->end()
+                                                            ->scalarNode('hidden')->defaultValue(false)->end()
+                                                        ->end()
                                                     ->end()
-                                                    ->prototype('scalar')->end()
                                                     ->defaultValue(array())
                                                 ->end() // attributes
                                                 ->scalarNode('accepted_name')->defaultValue('/^\w[\w\s\.\%\-]*$/u')->end()

--- a/Tests/DependencyInjection/ConfigurationLoadTest.php
+++ b/Tests/DependencyInjection/ConfigurationLoadTest.php
@@ -70,7 +70,15 @@ class ConfigurationLoadTest extends AbstractExtensionConfigurationTestCase
                                 'copy_from' => true,
                                 'copy_to' => true,
                                 'upload_overwrite' => true,
-                                'attributes' => array(),
+                                'attributes' => array(
+                                    'some_pattern' => array(
+                                        'pattern' => '/^some_pattern$/',
+                                        'read'    => true,
+                                        'write'   => true,
+                                        'locked'  => false,
+                                        'hidden'  => false,
+                                    )
+                                ),
                                 'accepted_name' => '/^\w[\w\s\.\%\-]*$/u',
                                 'check_subfolders' => true,
                                 'separator' => DIRECTORY_SEPARATOR,
@@ -99,7 +107,7 @@ class ConfigurationLoadTest extends AbstractExtensionConfigurationTestCase
                                 ),
                                 's3_settings' => array(
                                     'enabled' => false,
-                                )
+                                ),
                             ),
                         ),
                     ),

--- a/Tests/Fixtures/config/config.php
+++ b/Tests/Fixtures/config/config.php
@@ -32,6 +32,15 @@ $container->loadFromExtension('fm_elfinder', array(
                             'host' => '127.0.0.1',
                             'user' => 'root',
                         ),
+                        'attributes' => array(
+                            'some_pattern' => array(
+                                'pattern' => '/^some_pattern$/',
+                                'read'    => true,
+                                'write'   => true,
+                                'locked'  => false,
+                                'hidden'  => false,
+                            )
+                        ),
                     ),
                 ),
             ),

--- a/Tests/Fixtures/config/config.xml
+++ b/Tests/Fixtures/config/config.xml
@@ -31,6 +31,15 @@
                             host="127.0.0.1"
                             user="root"
                             />
+                    <fm-elfinder:attributes>
+                        <fm-elfinder:some_pattern
+                                pattern="/^some_pattern$/"
+                                read="true"
+                                write="true"
+                                locked="false"
+                                hidden="false"
+                                />
+                    </fm-elfinder:attributes>
                 </fm-elfinder:root>
             </fm-elfinder:connector>
         </fm-elfinder:instance>

--- a/Tests/Fixtures/config/config.yml
+++ b/Tests/Fixtures/config/config.yml
@@ -25,3 +25,10 @@ fm_elfinder:
                         ftp_settings:
                             host: 127.0.0.1
                             user: root
+                        attributes:
+                            some_pattern:
+                                pattern: '/^some_pattern$/'
+                                read: true
+                                write: true
+                                locked: false
+                                hidden: false


### PR DESCRIPTION
The `attributes` configuration setting to set the permissions of files did not work.

See https://github.com/Studio-42/elFinder/wiki/Simple-file-permissions-control