### PR TITLE
Events unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 composer.lock
 Tests/cache
 Tests/log
-
+Tests/Functional/cache
+Tests/Functional/log

--- a/Tests/Controller/ElFinderControllerTest.php
+++ b/Tests/Controller/ElFinderControllerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace FM\ElfinderBundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use FM\ElfinderBundle\Event\ElFinderEvents;
+use FM\ElfinderBundle\Controller\ElFinderController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\DependencyInjection\Container;
+
+class ElFinderControllerTest extends WebTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->container = static::createClient()->getContainer();
+    }
+
+    public function testDispatchedPrePostExecutionEvents()
+    {
+        $preExecCount = 0;
+        $postExecCount = 0;
+        // storing the real event dispatcher
+        $eventDispatcher = $this->container->get('event_dispatcher');
+        // creating a container with mocked services for this test
+        $container = $this->getContainer($eventDispatcher);
+        // adding listeners        
+        $eventDispatcher->addListener(ElFinderEvents::PRE_EXECUTION, $preExecListener = function (ElFinderEvents $e) use (&$preExecCount) {
+            $preExecCount++;
+        });
+        $eventDispatcher->addListener(ElFinderEvents::POST_EXECUTION, $postExecListener = function (ElFinderEvents $e) use (&$postExecCount) {
+            $postExecCount++;
+        });
+
+        $controller = new ElFinderController();
+        $controller->setContainer($container);
+        $controller->loadAction(new Request(array('cmd' => 'info')), 'default', null);
+
+        $this->assertGreaterThan(0, $preExecCount);
+        $this->assertGreaterThan(0, $postExecCount);
+    }
+
+    private function getContainer($eventDispatcher)
+    {
+        $container = new Container();
+        $container->set('fm_elfinder.loader', $this->getElFinderLoaderMock());
+        $container->set('http_kernel', $this->getHttpKernelMock());
+        $container->set('event_dispatcher', $eventDispatcher);
+        return $container;
+    }
+
+    private function getElFinderLoaderMock()
+    {
+        $stub = $this->getMockBuilder('FM\ElfinderBundle\Loader\ElFinderLoader')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $stub->expects($this->once())
+            ->method('load')
+            ->willReturn(array());
+        return $stub;
+    }
+
+    private function getHttpKernelMock()
+    {
+        $stub = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        return $stub;
+    }
+}

--- a/Tests/Event/ElFinderPostExecutionEventTest.php
+++ b/Tests/Event/ElFinderPostExecutionEventTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace FM\ElfinderBundle\Tests\Event;
+
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use FM\ElfinderBundle\Event\ElFinderPostExecutionEvent;
+
+class ElFinderPostExecutionEventTest extends TestCase
+{
+    public function testHasErrors()
+    {
+        $request = new Request();
+        $httpKernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $event = new ElFinderPostExecutionEvent($request, $httpKernel, 'testInstance', 'testHomeFolder', array());
+        $this->assertEquals(false, $event->hasErrors());
+
+        $event = new ElFinderPostExecutionEvent($request, $httpKernel, 'testInstance', 'testHomeFolder', array('error' => true));
+        $this->assertEquals(true, $event->hasErrors());
+    }
+}

--- a/Tests/Event/ElFinderPreExecutionEventTest.php
+++ b/Tests/Event/ElFinderPreExecutionEventTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace FM\ElfinderBundle\Tests\Event;
+
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use FM\ElfinderBundle\Event\ElFinderPreExecutionEvent;
+
+class ElFinderPreExecutionEventTest extends TestCase
+{
+    public function testGetCommand()
+    {
+        $command = 'rm';
+        $request = new Request(array('cmd' => $command));
+        $httpKernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $event = new ElFinderPreExecutionEvent($request, $httpKernel, 'testInstance', 'testHomeFolder');
+        $this->assertEquals($command, $event->getCommand());
+    }
+
+    public function testSubRequest()
+    {
+        $request = new Request(array('cmd' => 'info'));
+        $httpKernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $httpKernel
+            ->expects($this->once())
+            ->method('handle');
+        $event = new ElFinderPreExecutionEvent($request, $httpKernel, 'testInstance', 'testHomeFolder');
+        
+        $jsonResponse = $event->subRequest(array(
+            'instance' => $event->getInstance(),
+            'homeFolder' => $event->getHomeFolder()
+        ), $request->query->all());
+    }
+}

--- a/Tests/Functional/AppKernel.php
+++ b/Tests/Functional/AppKernel.php
@@ -1,0 +1,23 @@
+<?php
+
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+class AppKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        $bundles = array(
+            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new Symfony\Bundle\TwigBundle\TwigBundle(),
+            new FM\ElfinderBundle\FMElfinderBundle(),
+        );
+
+        return $bundles;
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(__DIR__.'/config/config_'.$this->getEnvironment().'.yml');
+    }
+}

--- a/Tests/Functional/config/config.yml
+++ b/Tests/Functional/config/config.yml
@@ -1,0 +1,39 @@
+framework:
+    secret:          "thisismysecret"
+    router:
+        resource: "%kernel.root_dir%/config/routing.yml"
+        strict_requirements: ~
+    form:            ~
+    csrf_protection: ~
+    validation:      { enable_annotations: true }
+    templating:
+        engines: ['twig']
+    default_locale:  "en"
+    trusted_hosts:   ~
+    trusted_proxies: ~
+    session:
+        # handler_id set to null will use default session handler from php.ini
+        handler_id:  ~
+    fragments:       ~
+    http_method_override: true
+
+
+# ElFinder file manager
+fm_elfinder:
+    instances:
+        default:
+            locale: en # defaults to current request locale
+            editor: custom # other options are tinymce, tinymce4, form, custom and simple, 
+            cors_support: true # full symfony life cycle
+            fullscreen: true # defaults true, applies to simple and ckeditor editors
+            include_assets: true # disable if you want to handle loading of the javascript and css assets yourself
+            connector:
+                debug: false # defaults to false
+                roots:       # at least one root must be defined
+                    uploads:
+                        show_hidden: false # defaults to false
+                        driver: LocalFileSystem
+                        volume_id: 1
+                        path: uploads
+
+

--- a/Tests/Functional/config/config_test.yml
+++ b/Tests/Functional/config/config_test.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: config.yml }
+
+framework:
+    test: ~
+    session:
+        storage_id: session.storage.mock_file
+    profiler:
+        collect: false

--- a/Tests/Functional/config/routing.yml
+++ b/Tests/Functional/config/routing.yml
@@ -1,0 +1,4 @@
+# ElFinder file manager
+elfinder:
+    resource: "@FMElfinderBundle/Resources/config/routing.yml"
+

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     ],
     "require": {
         "php":                           ">=5.3.3",
+        "symfony/symfony":               "~2.4",
         "symfony/framework-bundle":      "~2.4",
         "symfony/twig-bundle":           "~2.4",
         "helios-ag/fm-elfinder-php-connector": "~2.0",


### PR DESCRIPTION
Unit tests for events added in PR #128 :
- Testing the dispatching of pre and post execution events
- Testing the `hasErrors` function of postExecutionEvent
- Testing the `getCommand` and `subRequest` functions of preExecutionEvent

Sorry for not having pushed it earlier, I wasn't very familiar with unit tests :stuck_out_tongue_closed_eyes: 

See you :wink: 