### PR TITLE
updating connector dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/symfony":               "~2.4",
         "symfony/framework-bundle":      "~2.4",
         "symfony/twig-bundle":           "~2.4",
-        "helios-ag/fm-elfinder-php-connector": "~2.0",
+        "helios-ag/fm-elfinder-php-connector": "~2.3",
         "components/elfinder": "~1.0"
     },
     "require-dev" : {


### PR DESCRIPTION
Related to [issue 22](https://github.com/helios-ag/ElFinderPHP/issues/22 "Missing argument 1 for FM\\ElFinderPHP\\Connector\\ElFinderConnector::run()") on connector lib.