### PR TITLE
Created ElFinderPreExecutionException class.

### DIFF
--- a/Controller/ElFinderController.php
+++ b/Controller/ElFinderController.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
 use FM\ElfinderBundle\Event\ElFinderEvents;
 use FM\ElfinderBundle\Event\ElFinderPreExecutionEvent;
 use FM\ElfinderBundle\Event\ElFinderPostExecutionEvent;
+use FM\ElfinderBundle\Exception\ElFinderPreExecutionException;
 
 /**
  * Loader service for Elfinder backend
@@ -184,8 +185,12 @@ class ElFinderController extends Controller
     {
         $httpKernel = $this->get('http_kernel');
 
-        $preExecutionEvent = new ElFinderPreExecutionEvent($request, $httpKernel, $instance, $homeFolder);
-        $this->get('event_dispatcher')->dispatch(ElFinderEvents::PRE_EXECUTION, $preExecutionEvent);
+        try {
+            $preExecutionEvent = new ElFinderPreExecutionEvent($request, $httpKernel, $instance, $homeFolder);
+            $this->get('event_dispatcher')->dispatch(ElFinderEvents::PRE_EXECUTION, $preExecutionEvent);
+        } catch (ElFinderPreExecutionException $e) {
+            return new JsonResponse(['error' => $e->getMessage()]);
+        }
 
         $loader = $this->get('fm_elfinder.loader');
         $result = $loader->load($request, $instance);

--- a/Exception/ElFinderPreExecutionException.php
+++ b/Exception/ElFinderPreExecutionException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace FM\ElfinderBundle\Exception;
+
+class ElFinderPreExecutionException extends \Exception
+{
+}


### PR DESCRIPTION
- Catch ElFinderPreExecutionException from PreExecutionEvent listener and throw error to the client.

This makes it so developers can put in their own logic for permissions and other things. In my case, I have a custom ACL that I need to plug into FMELfinderbundle to prevent users from performing certain actions on select files/folders.