### PR TITLE
encode/decode access from FMElfinderBundle Loader (2/2) 

### DIFF
--- a/Loader/ElFinderLoader.php
+++ b/Loader/ElFinderLoader.php
@@ -81,4 +81,39 @@ class ElFinderLoader
     {
         $this->configurator = $configurator;
     }
+    
+    /**
+	 * Encode path into hash
+	 *
+	 * @var Request
+	 * @param  string
+	 * @throws \Exception
+	 * @return string
+	 **/
+	public function encode(Request $Request, $path) {
+
+		$target = ($Request->isMethod('POST')) ? $Request->get('target') : $Request->query->get('target');
+
+		if (empty($target)) {
+			throw new Exception('Request: target parameter is empty. Volume id can\'t be found');
+		}
+
+		$Volume = $this->Bridge->getVolume($target);
+
+		return $Volume->encode($path);
+	}
+
+	/**
+	 * Decode path from hash
+	 *
+	 * @param  string
+	 * @throws \Exception
+	 * @return string
+	 **/
+	public function decode($hash) {
+
+		$Volume = $this->Bridge->getVolume($hash);
+
+		return $Volume->decode($hash);
+	}
 }

--- a/README.md
+++ b/README.md
@@ -300,6 +300,35 @@ If you don't, the symfony life cycle won't end properly and so the event won't b
 
 You can access to all commands names [here](https://github.com/helios-ag/ElFinderPHP/blob/master/src/ElFinder.php#L61 "elFinder commands").
 
+If the default behavior doesn't suit you, you can also change a command parameter just like that:
+
+```xml
+<!-- src/AppBundle/Resources/config/services.xml -->
+<service id="app_bundle.listener.elfinder_pre_execution" class="AppBundle\EventListener\ElFinder\PreExecutionListener">
+    <tag name="fm_elfinder.event_listener" event="fm_elfinder.event.pre_execution" method="onPreExecute" />
+</service>
+```
+
+```php
+// src/AppBundle/EventListener/ElFinder/PostExecutionListener.php
+namespace AppBundle\EventListener\ElFinder;
+
+use FM\ElfinderBundle\Event\ElFinderPreExecutionEvent;
+
+class PreExecutionListener
+{
+    /**
+     * @param  ElFinderPreExecutionEvent $event
+     */
+    public function onPreExecute(ElFinderPreExecutionEvent $event)
+    {
+        if ($event->getCommand() == 'upload') {
+        	$event->getRequest()->query->set('upload_path', array('/myDirectory/') );	// relative path
+        }
+    }
+}
+```
+
 ### Sub requests
 
 Events allows you to perform sub requests (only for commands used with HTTP GET method, i.e. not to upload a file).

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ class PreExecutionListener
     public function onPreExecute(ElFinderPreExecutionEvent $event)
     {
         if ($event->getCommand() == 'upload') {
-        	$event->getRequest()->query->set('upload_path', array('/myDirectory/') );	// relative path
+        	$event->getRequest()->query->set('upload_path', array('/myDirectory/') );  // relative path
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ class PreExecutionListener
 
 ### Sub requests
 
-Events allows you to perform sub requests (only for commands used with HTTP GET method, i.e. not to upload a file).
+Events allows you to perform sub requests.
 These subrequests are working the same way than `forward` function on symfony controllers,
 and are also hookable.
 


### PR DESCRIPTION
i couldn't find a way to not commit the readme.md.
so if you could just cancel that file =x