### PR TITLE
Access to the encode/decode function From onPreExecute (2/2)

### DIFF
--- a/Controller/ElFinderController.php
+++ b/Controller/ElFinderController.php
@@ -182,13 +182,14 @@ class ElFinderController extends Controller
      */
     public function loadAction(Request $request, $instance, $homeFolder)
     {
-        $httpKernel = $this->get('http_kernel');
+        $loader = $this->get('fm_elfinder.loader');
+        $loader->initBridge($instance); // builds up the Bridge object for the loader with the given instance
 
+        $httpKernel        = $this->get('http_kernel');
         $preExecutionEvent = new ElFinderPreExecutionEvent($request, $httpKernel, $instance, $homeFolder);
         $this->get('event_dispatcher')->dispatch(ElFinderEvents::PRE_EXECUTION, $preExecutionEvent);
 
-        $loader = $this->get('fm_elfinder.loader');
-        $result = $loader->load($request, $instance);
+        $result = $loader->load($request); // the instance is already set
 
         $postExecutionEvent = new ElFinderPostExecutionEvent($request, $httpKernel, $instance, $homeFolder, $result);
         $this->get('event_dispatcher')->dispatch(ElFinderEvents::POST_EXECUTION, $postExecutionEvent);


### PR DESCRIPTION
the 2 new function that i have provide recently can't be used in the onPreExecute Event.

So i had to entirely review the functionnality.

Now it is accessible on both onPreExecute & onPostExecute Event. AND it's much more easy to use.
As you don't have to provide the Request parameter in the method :P 

issue : https://github.com/helios-ag/FMElfinderBundle/issues/174

part 1/2 : https://github.com/helios-ag/ElFinderPHP/pull/33