### PR TITLE
Bundle configuration for visible mime types

### DIFF
--- a/Controller/ElFinderController.php
+++ b/Controller/ElFinderController.php
@@ -62,7 +62,7 @@ class ElFinderController extends Controller
         $theme          = $parameters['theme'];
         // convert to javascript array
         $onlyMimes      = count($parameters['visible_mime_types'])
-                              ? "['" . implode("','", $parameters['visible_mime_types']) . "']"
+                              ? "['".implode("','", $parameters['visible_mime_types'])."']"
                               : '[]';
         $result         = array();
 

--- a/Controller/ElFinderController.php
+++ b/Controller/ElFinderController.php
@@ -60,6 +60,10 @@ class ElFinderController extends Controller
         $pathPrefix     = $parameters['path_prefix'];
         $includeAssets  = $parameters['include_assets'];
         $theme          = $parameters['theme'];
+        // convert to javascript array
+        $onlyMimes      = count($parameters['visible_mime_types'])
+                              ? "['" . implode("','", $parameters['visible_mime_types']) . "']"
+                              : '[]';
         $result         = array();
 
         switch ($editor) {
@@ -79,6 +83,7 @@ class ElFinderController extends Controller
                     'prefix'        => $assetsPath,
                     'theme'         => $theme,
                     'pathPrefix'    => $pathPrefix,
+                    'onlyMimes'     => $onlyMimes,
                 );
 
                 return $result;
@@ -94,6 +99,7 @@ class ElFinderController extends Controller
                     'prefix'        => $assetsPath,
                     'theme'         => $theme,
                     'pathPrefix'    => $pathPrefix,
+                    'onlyMimes'     => $onlyMimes,
                 );
 
                 return $result;
@@ -109,6 +115,7 @@ class ElFinderController extends Controller
                     'prefix'        => $assetsPath,
                     'theme'         => $theme,
                     'pathPrefix'    => $pathPrefix,
+                    'onlyMimes'     => $onlyMimes,
                 );
 
                 return $result;
@@ -123,6 +130,7 @@ class ElFinderController extends Controller
                     'prefix'             => $assetsPath,
                     'theme'              => $theme,
                     'pathPrefix'         => $pathPrefix,
+                    'onlyMimes'          => $onlyMimes,
                 );
 
                 return $result;
@@ -137,6 +145,7 @@ class ElFinderController extends Controller
                     'prefix'        => $assetsPath,
                     'theme'         => $theme,
                     'pathPrefix'    => $pathPrefix,
+                    'onlyMimes'     => $onlyMimes,
                 );
 
                 return $result;
@@ -151,6 +160,7 @@ class ElFinderController extends Controller
                     'prefix'        => $assetsPath,
                     'theme'         => $theme,
                     'pathPrefix'    => $pathPrefix,
+                    'onlyMimes'     => $onlyMimes,
                 );
 
                 return $result;
@@ -167,6 +177,7 @@ class ElFinderController extends Controller
                     'prefix'        => $assetsPath,
                     'theme'         => $theme,
                     'pathPrefix'    => $pathPrefix,
+                    'onlyMimes'     => $onlyMimes,
                 );
 
                 return $result;
@@ -179,6 +190,7 @@ class ElFinderController extends Controller
                     'instance'      => $instance,
                     'homeFolder'    => $homeFolder,
                     'prefix'        => $assetsPath,
+                    'onlyMimes'     => $onlyMimes,
                 );
 
                 return $result;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -47,6 +47,16 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('tinymce_popup_path')->defaultValue('')->end()
                             ->booleanNode('relative_path')->defaultTrue()->end()
                             ->scalarNode('path_prefix')->defaultValue('/')->end()
+                            ->arrayNode('visible_mime_types')
+                                ->beforeNormalization()
+                                    ->ifTrue(function ($v) { return is_string($v); })
+                                    ->then(function ($v) {
+                                        return array_map('trim', explode(',', $v));
+                                    })
+                                ->end()
+                                ->prototype('scalar')->end()
+                                ->defaultValue(array())
+                            ->end()
                             ->arrayNode('connector')
                                 ->addDefaultsIfNotSet()
                                 ->fixXmlConfig('root')

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ fm_elfinder:
             #fullscreen: true|false # defaults true, applies to simple and ckeditor editors
             #theme: smoothness # jquery theme, default is 'smoothness'
             include_assets: true # disable if you want to handle loading of the javascript and css assets yourself
+            #visible_mime_types: ['image/png', 'image/jpg', 'image/jpeg'] # only show these mime types, defaults to show all
             connector:
                 #debug: true|false # defaults to false
                 roots:       # at least one root must be defined

--- a/Resources/views/Elfinder/ckeditor.html.twig
+++ b/Resources/views/Elfinder/ckeditor.html.twig
@@ -24,6 +24,7 @@
         var f = $('.elfinder').elfinder({
             url : '{{path('ef_connect', {'instance': instance, 'homeFolder': homeFolder })}}'+'?mode='+mode,
             lang : '{{locale}}',
+            onlyMimes: {{ onlyMimes|raw }},
             getFileCallback : function(file) {
                 if (funcNum) {
                     {% if relative_path %}

--- a/Resources/views/Elfinder/elfinder_type.html.twig
+++ b/Resources/views/Elfinder/elfinder_type.html.twig
@@ -14,6 +14,7 @@
         var $f = $('.elfinder').elfinder({
             url : '{{path('ef_connect', { 'instance': instance, 'homeFolder': homeFolder } )}}',
             lang : '{{locale}}',
+            onlyMimes: {{ onlyMimes|raw }},
             getFileCallback: function(file) {
                 {% if relative_path %}
                     window.opener.setValue('{{ pathPrefix }}'+file.url.replace("{{ app.request.schemeAndHttpHost }}/", ""), "{{ id }}");

--- a/Resources/views/Elfinder/fm_tinymce.html.twig
+++ b/Resources/views/Elfinder/fm_tinymce.html.twig
@@ -23,6 +23,7 @@
             // set your elFinder options here
             url: '{{ path('ef_connect', {'instance': instance, 'homeFolder': homeFolder }) }}',  // connector URL
             lang : '{{ locale }}',
+            onlyMimes: {{ onlyMimes|raw }},
             getFileCallback: function(file) { // editor callback
                 {% if relative_path %}
                         file.url = '{{ pathPrefix }}' + file.url.replace("{{ app.request.schemeAndHttpHost }}/", "");

--- a/Resources/views/Elfinder/simple.html.twig
+++ b/Resources/views/Elfinder/simple.html.twig
@@ -13,7 +13,8 @@
     $().ready(function() {
         var $f = $('.elfinder').elfinder({
             url : '{{path('ef_connect', { 'instance': instance, 'homeFolder': homeFolder } )}}',
-            lang : '{{locale}}'
+            lang : '{{locale}}',
+            onlyMimes: {{ onlyMimes|raw }}
         });
 
         {% if fullscreen %}

--- a/Resources/views/Elfinder/summernote.html.twig
+++ b/Resources/views/Elfinder/summernote.html.twig
@@ -14,6 +14,7 @@
         var elf = $('.elfinder').elfinder({
             url : '{{ path('ef_connect', {'instance': instance, 'homeFolder': homeFolder }) }}',  // connector URL
             lang : '{{locale}}',
+            onlyMimes: {{ onlyMimes|raw }},
             destroyOnClose : true,
             getFileCallback : function(files, fm) {
                 window.opener.$('.summernote').summernote('editor.insertImage',files.url);

--- a/Resources/views/Elfinder/tinymce.html.twig
+++ b/Resources/views/Elfinder/tinymce.html.twig
@@ -45,6 +45,7 @@
         var f = $('.elfinder').elfinder({
             url : '{{ path('ef_connect', {'instance': instance, 'homeFolder': homeFolder }) }}',
             lang : '{{ locale }}',
+            onlyMimes: {{ onlyMimes|raw }},
             getfile : {
                 onlyURL : true,
                 multiple : false,

--- a/Resources/views/Elfinder/tinymce4.html.twig
+++ b/Resources/views/Elfinder/tinymce4.html.twig
@@ -28,6 +28,7 @@
             // set your elFinder options here
             url: '{{ path('ef_connect', {'instance': instance, 'homeFolder': homeFolder }) }}',  // connector URL
             lang : '{{ locale }}',
+            onlyMimes: {{ onlyMimes|raw }},
             getFileCallback: function(file) { // editor callback
                 {% if relative_path %}
                         FileBrowserDialogue.mySubmit('{{ pathPrefix }}'+file.url.replace("{{ app.request.schemeAndHttpHost }}/", "")); // pass selected file path to TinyMCE

--- a/Tests/DependencyInjection/ConfigurationLoadTest.php
+++ b/Tests/DependencyInjection/ConfigurationLoadTest.php
@@ -39,6 +39,7 @@ class ConfigurationLoadTest extends AbstractExtensionConfigurationTestCase
                     'tinymce_popup_path' => '/pop-up',
                     'relative_path'      => false,
                     'path_prefix'        => '/',
+                    'visible_mime_types' => array(),
                     'connector'          => array(
                         'debug'   => true,
                         'binds'   => array(),


### PR DESCRIPTION
The Elfinder JS plugin has an option called `onlyMimes` that will only show those kinds of files in the file browser. Previously, overriding the Controller and templates was the only way to set this option.

Now, the `visible_mime_types` can be set per Elfinder instance, through the bundle configuration.

You might notice that I convert the `visible_mime_types` variable from a PHP array to a string representation of a JS array, before passing to the templates. This is to keep the templates cleaner.