### PR TITLE
wrap jQuery around DOMContentLoaded

### DIFF
--- a/Resources/views/Form/elfinder_widget.html.twig
+++ b/Resources/views/Form/elfinder_widget.html.twig
@@ -2,9 +2,12 @@
     <input type="text" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %} data-type="elfinder-input-field" />
     {% if enable and instance is defined %}
         <script type="text/javascript" charset="utf-8">
-            $('[data-type="elfinder-input-field"][id="{{ id }}"]').on("click",function() {
-                var childWin = window.open("{{path('elfinder', {'instance': instance, 'homeFolder': homeFolder })}}?id={{ id }}", "popupWindow", "height=450, width=900");
+            document.addEventListener("DOMContentLoaded", function(event) {
+                $('[data-type="elfinder-input-field"][id="{{ id }}"]').on("click",function() {
+                    var childWin = window.open("{{path('elfinder', {'instance': instance, 'homeFolder': homeFolder })}}?id={{ id }}", "popupWindow", "height=450, width=900");
+                });
             });
+            
             function setValue(value, element_id) {
                 $('[data-type="elfinder-input-field"]' + (element_id ? '[id="'+ element_id +'"]': '')).val(value).change();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

jQuery is included at the end of my page, and thus is not ready when the form element is rendered.

DOMContentLoaded is compatible with all web browsers except IE8 (http://caniuse.com/#feat=domcontentloaded).
