### PR TITLE
Allow Flysystem filesystem service to be injected directly without ex…

### DIFF
--- a/Configuration/ElFinderConfigurationReader.php
+++ b/Configuration/ElFinderConfigurationReader.php
@@ -86,10 +86,16 @@ class ElFinderConfigurationReader implements ElFinderConfigurationProviderInterf
                 $pathAndHomeFolder = sprintf('%s%s', $path, $homeFolder);
             }
             if ($parameter['flysystem']['enabled']) {
-                $adapter     = $parameter['flysystem']['type']; // ftp ex.
-                $opt         = $parameter['flysystem']['options'];
-                $serviceName = $parameter['flysystem']['adapter_service'];
-                $filesystem  = $this->configureFlysystem($opt, $adapter, $serviceName);
+                if ($parameter['flysystem']['filesystem']) {
+                    $serviceName = $parameter['flysystem']['filesystem'];
+                    $filesystem  = $this->getFlysystemFilesystem($serviceName);
+                }
+                else {
+                    $adapter     = $parameter['flysystem']['type']; // ftp ex.
+                    $serviceName = $parameter['flysystem']['adapter_service'];
+                    $opt         = $parameter['flysystem']['options'];
+                    $filesystem  = $this->configureFlysystem($opt, $adapter, $serviceName);
+                }
             }
             $driver = $this->container->has($parameter['driver']) ? $this->container->get($parameter['driver']) : null;
 
@@ -255,6 +261,14 @@ class ElFinderConfigurationReader implements ElFinderConfigurationProviderInterf
                 break;
         }
 
+        return $filesystem;
+    }
+
+    private function getFlysystemFilesystem($serviceName) {
+        $filesystem = $this->container->get($serviceName);
+        if (!is_object($filesystem) || (!$filesystem instanceof Filesystem)) {
+            throw new \Exception(sprintf('Service %s is not an instance of %s.', $serviceName, Filesystem::class));
+        }
         return $filesystem;
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -196,6 +196,7 @@ class Configuration implements ConfigurationInterface
                                                 ->arrayNode('flysystem')
                                                     ->canBeEnabled()
                                                     ->children()
+                                                        ->scalarNode('filesystem')->defaultValue('')->end()
                                                         ->scalarNode('type')->defaultValue('')->end()
                                                         ->scalarNode('adapter_service')->defaultValue('')->end()
                                                         ->append($this->createFlysystemNode())


### PR DESCRIPTION
```
fm_elfinder:
    instances:
        default:
            connector:
                roots:
                    uploads:
                        driver: Flysystem
                        flysystem:
                            filesystem: 'app.flysystem_filesystem_service'
```

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
