### PR TITLE
Fixed twig extension for SF4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - 7.2
 
 sudo: false
 
@@ -17,9 +17,8 @@ env:
     global:
         - COMPOSER_PREFER_LOWEST=false
         - SYMFONY_DEPRECATIONS_HELPER=weak
-        - SYMFONY_VERSION=2.4.*
-        - SYMFONY_PHPUNIT_BRIDGE_VERSION=2.7.*
-
+        - SYMFONY_PHPUNIT_BRIDGE_VERSION=2.8.*
+        - SYMFONY_VERSION=2.8.*
 matrix:
     include:
         - php: 5.6
@@ -29,19 +28,20 @@ matrix:
         - php: 5.6
           env: SYMFONY_VERSION=3.1.* SYMFONY_PHPUNIT_BRIDGE_VERSION=3.1.* SYMFONY_DEPRECATIONS_HELPER=strict
         - php: 5.6
-          env: SYMFONY_VERSION=3.2.* SYMFONY_PHPUNIT_BRIDGE_VERSION=3.1.* SYMFONY_DEPRECATIONS_HELPER=strict
-        - php: 7.0
-          env: SYMFONY_VERSION=2.8.* SYMFONY_PHPUNIT_BRIDGE_VERSION=2.8.* SYMFONY_DEPRECATIONS_HELPER=strict
-        - php: 7.0
-          env: SYMFONY_VERSION=3.2.* SYMFONY_PHPUNIT_BRIDGE_VERSION=3.1.* SYMFONY_DEPRECATIONS_HELPER=strict
+          env: SYMFONY_VERSION=3.2.* SYMFONY_PHPUNIT_BRIDGE_VERSION=3.2.* SYMFONY_DEPRECATIONS_HELPER=strict
+        - php: 5.6
+          env: SYMFONY_VERSION=3.3.* SYMFONY_PHPUNIT_BRIDGE_VERSION=3.3.* SYMFONY_DEPRECATIONS_HELPER=strict
         - php: 7.1
-          env: SYMFONY_VERSION=2.8.* SYMFONY_PHPUNIT_BRIDGE_VERSION=2.8.* SYMFONY_DEPRECATIONS_HELPER=strict
+          env: SYMFONY_VERSION=3.4.* SYMFONY_PHPUNIT_BRIDGE_VERSION=3.4.* SYMFONY_DEPRECATIONS_HELPER=strict
         - php: 7.1
-          env: SYMFONY_VERSION=3.2.* SYMFONY_PHPUNIT_BRIDGE_VERSION=3.1.* SYMFONY_DEPRECATIONS_HELPER=strict
+          env: SYMFONY_VERSION=4.0.* SYMFONY_PHPUNIT_BRIDGE_VERSION=4.0.* SYMFONY_DEPRECATIONS_HELPER=strict
+        - php: 7.2
+          env: SYMFONY_VERSION=4.0.* SYMFONY_PHPUNIT_BRIDGE_VERSION=4.0.* SYMFONY_DEPRECATIONS_HELPER=strict
 install:
   - composer self-update
-  - composer require --no-update symfony/framework-bundle:${SYMFONY_VERSION}
-  - composer require --no-update symfony/form:${SYMFONY_VERSION}
+  - if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
+  - composer require --no-update symfony/symfony:${SYMFONY_VERSION}
+  - composer require --no-update symfony/form:${SYMFONY_VERSION}  
   - composer require --dev --no-update symfony/phpunit-bridge:${SYMFONY_PHPUNIT_BRIDGE_VERSION}
   - if [[ "$SYMFONY_VERSION" = *dev* ]]; then sed -i "s/\"MIT\"/\"MIT\",\"minimum-stability\":\"dev\"/g" composer.json; fi
   - composer update --prefer-source `if [[ $COMPOSER_PREFER_LOWEST = true ]]; then echo "--prefer-lowest --prefer-stable"; fi`

--- a/Controller/ElFinderController.php
+++ b/Controller/ElFinderController.php
@@ -93,7 +93,7 @@ class ElFinderController extends Controller
 
                 return $result;
             case 'ckeditor':
-                $result['template'] = 'FMElfinderBundle:Elfinder:ckeditor.html.twig';
+                $result['template'] = '@FMElfinder/Elfinder/ckeditor.html.twig';
                 $result['params']   = array(
                     'locale'        => $locale,
                     'fullscreen'    => $fullScreen,
@@ -109,7 +109,7 @@ class ElFinderController extends Controller
 
                 return $result;
             case 'summernote':
-                $result['template'] = 'FMElfinderBundle:Elfinder:summernote.html.twig';
+                $result['template'] = '@FMElfinder/Elfinder/summernote.html.twig';
                 $result['params']   = array(
                     'locale'        => $locale,
                     'fullscreen'    => $fullScreen,
@@ -125,7 +125,7 @@ class ElFinderController extends Controller
 
                 return $result;
             case 'tinymce':
-                $result['template'] = 'FMElfinderBundle:Elfinder:tinymce.html.twig';
+                $result['template'] = '@FMElfinderBundle/Elfinder/tinymce.html.twig';
                 $result['params']   = array(
                     'locale'             => $locale,
                     'tinymce_popup_path' => $this->getAssetsUrl($parameters['tinymce_popup_path']),
@@ -140,7 +140,7 @@ class ElFinderController extends Controller
 
                 return $result;
             case 'tinymce4':
-                $result['template'] = 'FMElfinderBundle:Elfinder:tinymce4.html.twig';
+                $result['template'] = '@FMElfinder/Elfinder/tinymce4.html.twig';
                 $result['params']   = array(
                     'locale'        => $locale,
                     'includeAssets' => $includeAssets,
@@ -155,7 +155,7 @@ class ElFinderController extends Controller
 
                 return $result;
             case 'fm_tinymce':
-                $result['template'] = 'FMElfinderBundle:Elfinder:fm_tinymce.html.twig';
+                $result['template'] = '@FMElfinder/Elfinder/fm_tinymce.html.twig';
                 $result['params']   = array(
                     'locale'        => $locale,
                     'includeAssets' => $includeAssets,
@@ -170,7 +170,7 @@ class ElFinderController extends Controller
 
                 return $result;
             case 'form':
-                $result['template'] = 'FMElfinderBundle:Elfinder:elfinder_type.html.twig';
+                $result['template'] = '@FMElfinder/Elfinder/elfinder_type.html.twig';
                 $result['params']   = array(
                     'locale'        => $locale,
                     'fullscreen'    => $fullScreen,
@@ -187,7 +187,7 @@ class ElFinderController extends Controller
 
                 return $result;
             default:
-                $result['template'] = 'FMElfinderBundle:Elfinder:simple.html.twig';
+                $result['template'] = '@FMElfinder/Elfinder/simple.html.twig';
                 $result['params']   = array(
                     'locale'        => $locale,
                     'fullscreen'    => $fullScreen,

--- a/DependencyInjection/Compiler/TwigFormPass.php
+++ b/DependencyInjection/Compiler/TwigFormPass.php
@@ -17,7 +17,7 @@ class TwigFormPass implements CompilerPassInterface
         }
 
         $container->setParameter('twig.form.resources', array_merge(
-            array('FMElfinderBundle:Form:elfinder_widget.html.twig'),
+            array('@FMElfinder/Form/elfinder_widget.html.twig'),
             $container->getParameter('twig.form.resources')
         ));
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,7 +12,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  * sections are normalized, and merged.
  *
  * @author Al Ganiev <helios.ag@gmail.com>
- * @copyright 2012-2016 Al Ganiev
+ * @copyright 2012-2017 Al Ganiev
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 class Configuration implements ConfigurationInterface

--- a/DependencyInjection/FMElfinderExtension.php
+++ b/DependencyInjection/FMElfinderExtension.php
@@ -30,7 +30,8 @@ class FMElfinderExtension extends Extension
         $container->setParameter('fm_elfinder', $config);
         $container->setAlias('fm_elfinder.configurator', $config['configuration_provider']);
         $container->setAlias('fm_elfinder.loader', $config['loader']);
-
+        $container->getAlias('fm_elfinder.loader')->setPublic(true);
+        
         if (Kernel::VERSION_ID < 30000) {
             $container->getDefinition('fm_elfinder.form.type')
                 ->clearTag('form.type')

--- a/Resources/views/Elfinder/ckeditor.html.twig
+++ b/Resources/views/Elfinder/ckeditor.html.twig
@@ -3,12 +3,12 @@
 <head>
     <meta charset="utf-8">
     {% if includeAssets %}
-        {{ include("FMElfinderBundle:Elfinder:helper/assets_css.html.twig") }}
+        {{ include("@FMElfinder/Elfinder/helper/assets_css.html.twig") }}
     {% endif %}
 </head>
 <body>
 {% if includeAssets %}
-    {{ include("FMElfinderBundle:Elfinder:helper/assets_js.html.twig") }}
+    {{ include("@FMElfinder/Elfinder/helper/assets_js.html.twig") }}
 {% endif %}
 <script type="text/javascript" charset="utf-8">
     function getUrlParam(paramName) {

--- a/Resources/views/Elfinder/elfinder_type.html.twig
+++ b/Resources/views/Elfinder/elfinder_type.html.twig
@@ -2,12 +2,12 @@
 <html>
 <head>
     {% if includeAssets %}
-        {{ include("FMElfinderBundle:Elfinder:helper/assets_css.html.twig") }}
+        {{ include("@FMElfinder/Elfinder/helper/assets_css.html.twig") }}
     {% endif %}
 </head>
 <body>
 {% if includeAssets %}
-    {{ include("FMElfinderBundle:Elfinder:helper/assets_js.html.twig") }}
+    {{ include("@FMElfinder/Elfinder/helper/assets_js.html.twig") }}
 {% endif %}
 <script type="text/javascript" charset="utf-8">
     $().ready(function() {

--- a/Resources/views/Elfinder/fm_tinymce.html.twig
+++ b/Resources/views/Elfinder/fm_tinymce.html.twig
@@ -2,12 +2,12 @@
 <html>
 <head>
 {% if includeAssets %}
-    {{ include("FMElfinderBundle:Elfinder:helper/assets_css.html.twig") }}
+    {{ include("@FMElfinder/Elfinder:helper/assets_css.html.twig") }}
 {% endif %}
 </head>
 <body>
 {% if includeAssets %}
-    {{ include("FMElfinderBundle:Elfinder:helper/assets_js.html.twig") }}
+    {{ include("@FMElfinder/Elfinder/helper/assets_js.html.twig") }}
 {% endif %}
 <script type="text/javascript" charset="utf-8">
     var FileBrowserDialogue = {

--- a/Resources/views/Elfinder/simple.html.twig
+++ b/Resources/views/Elfinder/simple.html.twig
@@ -2,12 +2,12 @@
 <html>
 <head>
     {% if includeAssets %}
-        {{ include("FMElfinderBundle:Elfinder:helper/assets_css.html.twig") }}
+        {{ include("@FMElfinder/Elfinder/helper/assets_css.html.twig") }}
     {% endif %}
 </head>
 <body>
 {% if includeAssets %}
-    {{ include("FMElfinderBundle:Elfinder:helper/assets_js.html.twig") }}
+    {{ include("@FMElfinder/Elfinder/helper/assets_js.html.twig") }}
 {% endif %}
 <script type="text/javascript" charset="utf-8">
     $().ready(function() {

--- a/Resources/views/Elfinder/summernote.html.twig
+++ b/Resources/views/Elfinder/summernote.html.twig
@@ -2,12 +2,12 @@
 <html>
 <head>
     {% if includeAssets %}
-        {{ include("FMElfinderBundle:Elfinder:helper/assets_css.html.twig") }}
+        {{ include("@FMElfinder/Elfinder/helper/assets_css.html.twig") }}
     {% endif %}
 </head>
 <body>
 {% if includeAssets %}
-    {{ include("FMElfinderBundle:Elfinder:helper/assets_js.html.twig") }}
+    {{ include("@FMElfinder/Elfinder/helper/assets_js.html.twig") }}
 {% endif %}
 <script type="text/javascript" charset="utf-8">
     $(document).ready(function() {

--- a/Resources/views/Elfinder/tinymce.html.twig
+++ b/Resources/views/Elfinder/tinymce.html.twig
@@ -2,12 +2,12 @@
 <html>
 <head>
     {% if includeAssets %}
-        {{ include("FMElfinderBundle:Elfinder:helper/assets_css.html.twig") }}
+        {{ include("@FMElfinder/Elfinder/helper/assets_css.html.twig") }}
     {% endif %}
 </head>
 <body>
 {% if includeAssets %}
-    {{ include("FMElfinderBundle:Elfinder:helper/assets_js.html.twig") }}
+    {{ include("@FMElfinder/Elfinder/helper/assets_js.html.twig") }}
 {% endif %}
 <script type="text/javascript" src="{{ tinymce_popup_path }}"></script>
 <script type="text/javascript" charset="utf-8">

--- a/Resources/views/Elfinder/tinymce4.html.twig
+++ b/Resources/views/Elfinder/tinymce4.html.twig
@@ -2,12 +2,12 @@
 <html>
 <head>
 {% if includeAssets %}
-    {{ include("FMElfinderBundle:Elfinder:helper/assets_css.html.twig") }}
+    {{ include("@FMElfinder/Elfinder/helper/assets_css.html.twig") }}
 {% endif %}
 </head>
 <body>
 {% if includeAssets %}
-    {{ include("FMElfinderBundle:Elfinder:helper/assets_js.html.twig") }}
+    {{ include("@FMElfinder/Elfinder/helper/assets_js.html.twig") }}
 {% endif %}
 <script type="text/javascript" charset="utf-8">
     var FileBrowserDialogue = {

--- a/Tests/DependencyInjection/Compiler/TwigFormPassTest.php
+++ b/Tests/DependencyInjection/Compiler/TwigFormPassTest.php
@@ -20,7 +20,7 @@ class TwigFormPassTest extends \PHPUnit\Framework\TestCase
         $container->setParameter('twig.form.resources', array());
         $pass->process($container);
         $this->assertEquals(array(
-            'FMElfinderBundle:Form:elfinder_widget.html.twig',
+            '@FMElfinder/Form/elfinder_widget.html.twig',
         ), $container->getParameter('twig.form.resources'));
     }
 }

--- a/Twig/Extension/FMElfinderExtension.php
+++ b/Twig/Extension/FMElfinderExtension.php
@@ -50,7 +50,7 @@ class FMElfinderExtension extends \Twig_Extension
             throw new \Twig_Error_Runtime('The function can be applied to strings only.');
         }
 
-        return $this->twig->render('FMElfinderBundle:Elfinder/helper:_tinymce.html.twig',
+        return $this->twig->render('@FMElfinder/Elfinder/helper/_tinymce.html.twig',
             array(
                 'instance' => $instance,
                 'width'    => $parameters['width'],
@@ -73,7 +73,7 @@ class FMElfinderExtension extends \Twig_Extension
             throw new \Twig_Error_Runtime('The function can be applied to strings only.');
         }
 
-        return $this->twig->render('FMElfinderBundle:Elfinder/helper:_tinymce4.html.twig',
+        return $this->twig->render('@FMElfinder/Elfinder/helper/_tinymce4.html.twig',
             array(
                 'instance' => $instance,
                 'width'    => $parameters['width'],
@@ -97,7 +97,7 @@ class FMElfinderExtension extends \Twig_Extension
             throw new \Twig_Error_Runtime('The function can be applied to strings only.');
         }
 
-        return $this->twig->render('FMElfinderBundle:Elfinder/helper:_summernote.html.twig',
+        return $this->twig->render('@FMElfinder/Elfinder/helper/_summernote.html.twig',
             array(
                 'instance' => $instance,
                 'selector' => $selector,

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "keywords": ["elfinder","file manager","wysiwyg"],
     "type": "symfony-bundle",
     "homepage": "https://github.com/helios-ag/FMElfinderBundle",
+    "minimum-stability": "dev",    
     "license": "MIT",
     "authors": [
         {
@@ -20,18 +21,19 @@
     },
     "require": {
         "php":                                 "^5.6|^7.0",
-        "symfony/framework-bundle":            "~2.4|~3.0",
-        "symfony/twig-bundle":                 "~2.4|~3.0",
-        "symfony/form":                        "~2.4|~3.0",
+        "symfony/framework-bundle":            "~2.8|~3.0|~4.0",
+        "symfony/twig-bundle":                 "~2.8|~3.0|~4.0",
+        "symfony/form":                        "~2.8|~3.0|~4.0",
+        "symfony/asset":                       "~2.8|~3.0|~4.0",
         "helios-ag/fm-elfinder-php-connector": "~2.5",
         "components/elfinder":                 "~2.1",
         "robloach/component-installer":        "~0.2"
     },
     "require-dev" : {
-        "symfony/phpunit-bridge": "~2.7|~3.0",
-        "matthiasnoback/symfony-config-test":  "~1",
-        "matthiasnoback/symfony-dependency-injection-test": "~0.7",
-        "symfony/finder": "~2.4|~3.0",
+        "symfony/phpunit-bridge": "~2.8|~3.0|~4.0",
+        "matthiasnoback/symfony-config-test":  "~2",
+        "matthiasnoback/symfony-dependency-injection-test": "~1|~2",
+        "symfony/finder": "~2.8|~3.0|~4.0",
         "satooshi/php-coveralls": "~1",
         "phpunit/phpunit": "~5"
     },
@@ -45,7 +47,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "6.1-dev"
+            "dev-master": "7.0-dev"
         }
     }
 }


### PR DESCRIPTION
Corrected template paths for twig extension in SF4.

Also, I think you should fix the "assets_path" in the default configuration because in SF4 assets are placed in the public folder by default, but that is your decision. :)