### PR TITLE
Throw not found exception on unknown instance

### DIFF
--- a/Controller/ElFinderController.php
+++ b/Controller/ElFinderController.php
@@ -7,6 +7,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use FM\ElfinderBundle\Event\ElFinderEvents;
 use FM\ElfinderBundle\Event\ElFinderPreExecutionEvent;
 use FM\ElfinderBundle\Event\ElFinderPostExecutionEvent;
@@ -33,6 +34,10 @@ class ElFinderController extends Controller
     public function showAction(Request $request, $instance, $homeFolder)
     {
         $efParameters = $this->container->getParameter('fm_elfinder');
+
+        if (empty($efParameters['instances'][$instance])) {
+            throw new NotFoundHttpException('Instance not found');
+        }
         $parameters   = $efParameters['instances'][$instance];
 
         if (empty($parameters['locale'])) {


### PR DESCRIPTION
I believe a NotFoundException should be thrown when a instance is not found, instead of a possible PHP error.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
