### PR TITLE
Fix default encoding parameter value

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -81,7 +81,7 @@ class Configuration implements ConfigurationInterface
                                                 ->scalarNode('mimefile')->defaultValue('')->end()
                                                 ->scalarNode('security_voter')->defaultValue('')->end()
                                                 ->scalarNode('start_path')->defaultValue('')->end()
-                                                ->scalarNode('encoding')->defaultValue('')->end()
+                                                ->scalarNode('encoding')->defaultValue('UTF-8')->end()
                                                 ->scalarNode('url')->defaultValue('')->end()
                                                 ->scalarNode('alias')->defaultValue('')->end()
                                                 ->scalarNode('img_lib')->defaultValue('auto')->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | 
| License       | MIT

I upgraded to the latest v.8.0 version I faced to an issue with the new encoding parameter. When no value is provided, a 500 error is triggered with the message `Notice: Undefined index: encoding`
I just propose to change the default value to utf-8.