### PR TITLE
New way to referencing controller

### DIFF
--- a/src/Resources/config/routing.yml
+++ b/src/Resources/config/routing.yml
@@ -1,6 +1,6 @@
 ef_connect:
     path:  /efconnect/{instance}/{homeFolder}
-    defaults: { _controller: FMElfinderBundle:ElFinder:load, instance: default, homeFolder: '' }
+    defaults: { _controller: FM\ElfinderBundle\Controller\ElFinderController::loadAction, instance: default, homeFolder: '' }
 elfinder:
     path: /elfinder/{instance}/{homeFolder}
-    defaults: { _controller: FMElfinderBundle:ElFinder:show, instance: default, homeFolder: '' }
+    defaults: { _controller: FM\ElfinderBundle\Controller\ElFinderController::showAction, instance: default, homeFolder: '' }


### PR DESCRIPTION
Because the bundle notation has been deprecated in sf4.1 ( https://symfony.com/blog/new-in-symfony-4-1-deprecated-the-bundle-notation), namespace notation must be used.

Warning message (symfony profiler and running test):
User Deprecated: Referencing controllers with FMElfinderBundle:ElFinder:load is deprecated since Symfony 4.1, use "FM\ElfinderBundle\Controller\ElFinderController::loadAction" instead.
User Deprecated: Referencing controllers with FMElfinderBundle:ElFinder:show is deprecated since Symfony 4.1, use "FM\ElfinderBundle\Controller\ElFinderController::showAction" instead.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
