### PR TITLE
Explicitly call resize() after registering handler to always trigger resize on first load

### DIFF
--- a/src/Resources/views/Elfinder/ckeditor.html.twig
+++ b/src/Resources/views/Elfinder/ckeditor.html.twig
@@ -45,6 +45,7 @@
                 $ef.height(h -20).resize();
             }
         });
+        $(window).resize();
         {% endif %}
     });
 </script>

--- a/src/Resources/views/Elfinder/elfinder_type.html.twig
+++ b/src/Resources/views/Elfinder/elfinder_type.html.twig
@@ -34,6 +34,7 @@
             $f.height($win_height).resize();
         }
     });
+    $window.resize();
     {% endif %}
     });
 </script>

--- a/src/Resources/views/Elfinder/simple.html.twig
+++ b/src/Resources/views/Elfinder/simple.html.twig
@@ -25,6 +25,7 @@
                 $f.height($win_height).resize();
             }
         });
+        $window.resize();
         {% endif %}
     });
 </script>


### PR DESCRIPTION
When this is not done, the resize is not triggered correctly, resulting in a popup with elfinder only covering half size.

This behavior started after upgrading from 7 to 9, probably due to a change in elfinder itself.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT
