### PR TITLE
Throw not found exception on unknown instance

### DIFF
--- a/src/Controller/ElFinderController.php
+++ b/src/Controller/ElFinderController.php
@@ -9,6 +9,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use FM\ElfinderBundle\Event\ElFinderEvents;
 use FM\ElfinderBundle\Event\ElFinderPreExecutionEvent;
 use FM\ElfinderBundle\Event\ElFinderPostExecutionEvent;
@@ -32,6 +33,10 @@ class ElFinderController extends Controller
     public function showAction(Request $request, $instance, $homeFolder)
     {
         $efParameters = $this->container->getParameter('fm_elfinder');
+
+        if (empty($efParameters['instances'][$instance])) {
+            throw new NotFoundHttpException('Instance not found');
+        }
         $parameters   = $efParameters['instances'][$instance];
 
         if (empty($parameters['locale'])) {


### PR DESCRIPTION
Current behaviour is a PHP warning as url input is not correctly checkec, which results in an error page during development, but a white 200 OK response on production.

When catching this early with a `NotFoundException`, it is clear that the instance does not exist. 

This change adds two major improvements:
 - During development there will be a Symfony error page with a "Instance not found" instead of a "Notice: Undefined index: ".
 - The user on production will be presented with an accurate 404 not found page, which can be customized by the application (instead of a 200 OK page with some random content, but white result).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Note, this is the rebased version of #303, as I got no response there and the source has changed.