### PR TITLE
Post execution event fix

### DIFF
--- a/src/Connector/ElFinderConnector.php
+++ b/src/Connector/ElFinderConnector.php
@@ -73,4 +73,13 @@ class ElFinderConnector extends \elFinderConnector
 
         return $this->output($this->elFinder->exec($cmd, $this->input_filter($args)));
     }
+
+    protected function output(array $data)
+    {
+        if (isset($data['pointer'])) {
+            parent::output($data);
+        } else {
+            return $data;
+        }
+    }
 }


### PR DESCRIPTION
In standart elfinder connector there is `exit` in `output` method (dump).
https://github.com/Studio-42/elFinder/blob/b3a6555758656379c67e981a386c2fbc72507910/php/elFinderConnector.class.php#L290

echo and exit... Are you kidding ? 😄 

More description:
We will never be here 
https://github.com/helios-ag/FMElfinderBundle/blob/184dc241cb8473060218084d054d71ce1a9beacc/src/Controller/ElFinderController.php#L233