### PR TITLE
Add homeFolder to url

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ fm_elfinder:
 * **assets_path** - this is where css/js files of the bundle are, this options should be the same as composers `component-dir` option.
 * **default** - instance of elfinder, can be used to define multiple configurations of ElFinder, allows simultaneous configuration for different types of WYSIWYG editors in your project
 * **path** - define root directory for the files inside web/ directory, default is "uploads". Make sure to set proper write/read and owner permissions to this directory.
-* **url** - url to be prefixed to image path, for displaying. Can be either `absolute` or `relative`. If relative, it will be prefixed with the applications base-url. If left blank, url will be the base-url, append with the value of the 'path' parameter
+* **url** - url to be prefixed to image path, for displaying. Can be either `absolute` or `relative`. If absolute, you can use `{homeFolder}` string as placeholder which will be replaced automatically. If relative, it will be prefixed with the applications base-url. If left blank, url will be the base-url, append with the value of the 'path' parameter
 * **driver** - can be LocalFileSystem, FTP or MySQL, Flysystem, S3 and etc, check class FM\ElfinderBundle\DependencyInjection\Configuration   
 * **locale** - locale determines, which language, ElFinder will use, to translate user interface, default is current request locale
 * **cors_support** - allows cross domain responses handling (default false)

--- a/src/Configuration/ElFinderConfigurationReader.php
+++ b/src/Configuration/ElFinderConfigurationReader.php
@@ -178,7 +178,7 @@ class ElFinderConfigurationReader implements ElFinderConfigurationProviderInterf
     {
         if (isset($parameter['url']) && $parameter['url']) {
             if (0 === strpos($parameter['url'], 'http')) {
-                return $parameter['url'];
+                return str_replace('{homeFolder}', $homeFolder, $parameter['url']);
             }
 
             $path = $parameter['url'].'/'.$homeFolder;

--- a/tests/Configuration/ElFinderConfigurationReaderTest.php
+++ b/tests/Configuration/ElFinderConfigurationReaderTest.php
@@ -219,6 +219,58 @@ class ElFinderConfigurationReaderTest extends \PHPUnit\Framework\TestCase
                         ),
                     ),
                 ),
+                'without_path_with_url_absolute_homeFolder'  => array(
+                    'cors_support' => true,
+                    'connector'    => array(
+                        'debug' => '', 'binds' => '', 'plugins' => '',
+                        'roots' => array(
+                            'uploads' => array(
+                                'flysystem'         => array('enabled' => false),
+                                'volume_id'         => 2,
+                                'security_voter'    => '',
+                                'show_hidden'       => false,
+                                'path'              => '',
+                                'driver'            => 'LocalFileSystem',
+                                'url'               => 'https://test.com/{homeFolder}',
+                                'glide_url'         => '',
+                                'glide_key'         => '',
+                                'plugins'           => '',
+                                'driver_options'    => '',
+                                'start_path'        => '',
+                                'encoding'          => '',
+                                'alias'             => '',
+                                'mime_detect'       => '',
+                                'mimefile'          => '',
+                                'img_lib'           => '',
+                                'tmb_path'          => '',
+                                'tmb_path_mode'     => '',
+                                'tmb_url'           => '',
+                                'tmb_size'          => '',
+                                'tmb_crop'          => '',
+                                'tmb_bg_color'      => '',
+                                'copy_overwrite'    => '',
+                                'copy_join'         => '',
+                                'copy_from'         => '',
+                                'copy_to'           => '',
+                                'upload_overwrite'  => '',
+                                'upload_allow'      => '',
+                                'upload_deny'       => '',
+                                'upload_max_size'   => '',
+                                'defaults'          => '',
+                                'attributes'        => '',
+                                'accepted_name'     => '',
+                                'disabled_commands' => '',
+                                'tree_deep'         => '',
+                                'check_subfolders'  => '',
+                                'separator'         => '',
+                                'time_format'       => '',
+                                'archive_mimes'     => '',
+                                'archivers'         => '',
+                                'fileMode'          => '',
+                            ),
+                        ),
+                    ),
+                ),
             ),
         );
 
@@ -307,6 +359,12 @@ class ElFinderConfigurationReaderTest extends \PHPUnit\Framework\TestCase
         $configuration = $reader->getConfiguration('without_path_with_url');
         $this->assertEquals('/bob', $configuration['roots'][0]['path']);
         $this->assertEquals('http://test.com/unit-test/home-url-without-path/bob', $configuration['roots'][0]['URL']);
+
+        // without path and with url absolute and homeFolder
+        $reader        = $this->getConfigurationReader($this->getHomeFolderAwareAttributesObject());
+        $configuration = $reader->getConfiguration('without_path_with_url_absolute_homeFolder');
+        $this->assertEquals('/bob', $configuration['roots'][0]['path']);
+        $this->assertEquals('https://test.com/bob', $configuration['roots'][0]['URL']);
     }
 
     public function testAccessTmbURLOption()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

I needed to pass a `homeFolder` from the form type with currently logged in user, so it can modify it's own files. `homeFolder` was not added when url was not absolute.
Now you can use `{homeFolder}` as a placeholder in url and it will be replaced automatically.