### PR TITLE
Update twig extension to use supported Twig classes instead of legacy ones

### DIFF
--- a/src/Twig/Extension/FMElfinderExtension.php
+++ b/src/Twig/Extension/FMElfinderExtension.php
@@ -2,20 +2,27 @@
 
 namespace FM\ElfinderBundle\Twig\Extension;
 
+use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
 /**
  * Class FMElfinderExtension.
  */
-class FMElfinderExtension extends \Twig_Extension
+class FMElfinderExtension extends AbstractExtension
 {
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     protected $twig;
 
     /**
-     * @param \Twig_Environment $twig
+     * @param Environment $twig
      */
-    public function __construct(\Twig_Environment $twig)
+    public function __construct(Environment $twig)
     {
         $this->twig = $twig;
     }
@@ -30,9 +37,9 @@ class FMElfinderExtension extends \Twig_Extension
         $options = array('is_safe' => array('html'));
 
         return array(
-            new \Twig_SimpleFunction('elfinder_tinymce_init', array($this, 'tinymce'), $options),
-            new \Twig_SimpleFunction('elfinder_tinymce_init4', array($this, 'tinymce4'), $options),
-            new \Twig_SimpleFunction('elfinder_summernote_init', array($this, 'summernote'), $options),
+            new TwigFunction('elfinder_tinymce_init', array($this, 'tinymce'), $options),
+            new TwigFunction('elfinder_tinymce_init4', array($this, 'tinymce4'), $options),
+            new TwigFunction('elfinder_summernote_init', array($this, 'summernote'), $options),
         );
     }
 
@@ -42,14 +49,14 @@ class FMElfinderExtension extends \Twig_Extension
      *
      * @return mixed
      *
-     * @throws \Twig_Error_Loader
-     * @throws \Twig_Error_Runtime
-     * @throws \Twig_Error_Syntax
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
      */
     public function tinymce($instance = 'default', $parameters = array('width' => 900, 'height' => 450, 'title' => 'elFinder 2.0'))
     {
         if (!is_string($instance)) {
-            throw new \Twig_Error_Runtime('The function can be applied to strings only.');
+            throw new RuntimeError('The function can be applied to strings only.');
         }
 
         return $this->twig->render('@FMElfinder/Elfinder/helper/_tinymce.html.twig',
@@ -67,14 +74,14 @@ class FMElfinderExtension extends \Twig_Extension
      *
      * @return mixed
      *
-     * @throws \Twig_Error_Loader
-     * @throws \Twig_Error_Runtime
-     * @throws \Twig_Error_Syntax
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
      */
     public function tinymce4($instance = 'default', $parameters = array('width' => 900, 'height' => 450, 'title' => 'elFinder 2.0'))
     {
         if (!is_string($instance)) {
-            throw new \Twig_Error_Runtime('The function can be applied to strings only.');
+            throw new RuntimeError('The function can be applied to strings only.');
         }
 
         return $this->twig->render('@FMElfinder/Elfinder/helper/_tinymce4.html.twig',
@@ -93,14 +100,14 @@ class FMElfinderExtension extends \Twig_Extension
      *
      * @return mixed
      *
-     * @throws \Twig_Error_Loader
-     * @throws \Twig_Error_Runtime
-     * @throws \Twig_Error_Syntax
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
      */
     public function summernote($instance = 'default', $selector = '.summenote', $parameters = array('width' => 900, 'height' => 450, 'title' => 'elFinder 2.0'))
     {
         if (!is_string($instance)) {
-            throw new \Twig_Error_Runtime('The function can be applied to strings only.');
+            throw new RuntimeError('The function can be applied to strings only.');
         }
 
         return $this->twig->render('@FMElfinder/Elfinder/helper/_summernote.html.twig',

--- a/tests/Twig/Extension/FMElfinderExtensionTest.php
+++ b/tests/Twig/Extension/FMElfinderExtensionTest.php
@@ -9,6 +9,9 @@ use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Loader\YamlFileLoader;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Twig\Template;
 
 class FMElfinderExtensionTest extends \PHPUnit\Framework\TestCase
 {
@@ -21,15 +24,15 @@ class FMElfinderExtensionTest extends \PHPUnit\Framework\TestCase
     /** @var \FM\ElfinderBundle\Twig\Extension\FMElFinderExtension */
     protected $extension;
 
-    /** @var \Twig_Environment */
+    /** @var Environment */
     protected $twig;
 
-    /** @var \Twig_Template */
+    /** @var Template */
     protected $template;
 
     protected function setUp()
     {
-        $this->twig      = new \Twig_Environment(new \Twig_Loader_Filesystem(array(__DIR__.'/../../../src/Resources/views/Elfinder/helper')));
+        $this->twig      = new Environment(new FilesystemLoader(array(__DIR__.'/../../../src/Resources/views/Elfinder/helper')));
         $this->extension = new FMElfinderExtension($this->twig);
         $this->twig->addExtension($this->extension);
         $loader     = new YamlFileLoader(new FileLocator(__DIR__.'/../../../src/Resources/config'));
@@ -41,8 +44,7 @@ class FMElfinderExtensionTest extends \PHPUnit\Framework\TestCase
 
     public function testRenderTinyMCE3()
     {
-        $this->template = $this->twig->loadTemplate('_tinymce.html.twig');
-        $testData       = $this->renderTemplate(array('instance' => 'minimal'));
+        $testData = $this->twig->render('_tinymce.html.twig', array('instance' => 'minimal'));
 
         $expected = <<<'EOF'
 <script type="text/javascript">
@@ -72,8 +74,7 @@ EOF;
 
     public function testRenderTinyMCE4()
     {
-        $this->template = $this->twig->loadTemplate('_tinymce4.html.twig');
-        $testData       = $this->renderTemplate(array('instance' => 'minimal'));
+        $testData = $this->twig->render('_tinymce4.html.twig', array('instance' => 'minimal'));
 
         $expected = <<<'EOF'
 <script type="text/javascript">
@@ -99,8 +100,7 @@ EOF;
 
     public function testRenderSummernote()
     {
-        $this->template = $this->twig->loadTemplate('_summernote.html.twig');
-        $testData       = $this->renderTemplate(array('instance' => 'minimal'));
+        $testData = $this->twig->render('_summernote.html.twig', array('instance' => 'minimal'));
 
         $expected  = <<<'EOF'
 <script type="text/javascript">
@@ -132,14 +132,6 @@ EOF;
     }
 
     /**
-     * {@inheritdoc}
-     */
-    protected function renderTemplate(array $context = array())
-    {
-        return $this->template->render($context);
-    }
-
-    /**
      * Normalizes the output by removing the heading whitespaces.
      *
      * @param string $output the output
@@ -155,11 +147,11 @@ EOF;
     {
         $rc = new \ReflectionClass('FM\ElfinderBundle\Twig\Extension\FMElfinderExtension');
 
-        $this->assertTrue($rc->isSubclassOf('Twig_Extension'));
+        $this->assertTrue($rc->isSubclassOf('Twig\Extension\AbstractExtension'));
     }
 
     /**
-     * @expectedException \Twig_Error_Runtime
+     * @expectedException \Twig\Error\RuntimeError
      * @expectedExceptionMessage The function can be applied to strings only.
      */
     public function testSummernoteInstanceNotString()
@@ -168,7 +160,7 @@ EOF;
     }
 
     /**
-     * @expectedException \Twig_Error_Runtime
+     * @expectedException \Twig\Error\RuntimeError
      * @expectedExceptionMessage The function can be applied to strings only.
      */
     public function testTinyMCEInstanceNotString()
@@ -177,7 +169,7 @@ EOF;
     }
 
     /**
-     * @expectedException \Twig_Error_Runtime
+     * @expectedException \Twig\Error\RuntimeError
      * @expectedExceptionMessage The function can be applied to strings only.
      */
     public function testTinyMCE4InstanceNotString()
@@ -190,7 +182,7 @@ EOF;
         $twigFunctions = $this->extension->getFunctions();
 
         foreach ($twigFunctions as $twigFunction) {
-            $this->assertInstanceOf('Twig_SimpleFunction', $twigFunction);
+            $this->assertInstanceOf('Twig\TwigFunction', $twigFunction);
         }
     }
 }


### PR DESCRIPTION
It is as simple as replacing Twig_* classes with actual classes that are supported and available in all twig versions. Also updated test to reflect those changes.