### PR TITLE
Using asset() to ensure the URL is correct (if website not deployed under /)

### DIFF
--- a/src/Resources/views/Elfinder/helper/main.js.twig
+++ b/src/Resources/views/Elfinder/helper/main.js.twig
@@ -115,7 +115,7 @@
 
     // config of RequireJS (REQUIRED)
     require.config({
-        baseUrl : '/bundles/fmelfinder/js',
+        baseUrl : "{{ asset('bundles/fmelfinder/js') }}",
         paths : {
             'jquery'   : '//cdnjs.cloudflare.com/ajax/libs/jquery/'+(old? '1.12.4' : jqver)+'/jquery.min',
             'jquery-ui': '//cdnjs.cloudflare.com/ajax/libs/jqueryui/'+uiver+'/jquery-ui.min',


### PR DESCRIPTION
Hi,
If the website is not deployed under `/`, the bundle actualy doesn't work because of the `baseUrl` present in the `elfinder.main.js` that specifies `/bundles...`, using the `asset()` function fixes this issue.