### PR TITLE
Setting MIME reply to text/javascript for mainJS

### DIFF
--- a/src/Controller/ElFinderController.php
+++ b/src/Controller/ElFinderController.php
@@ -233,6 +233,9 @@ class ElFinderController extends AbstractController
 
     public function mainJS()
     {
-        return $this->render('@FMElfinder/Elfinder/helper/main.js.twig');
+        return new Response(
+            $this->renderView('@FMElfinder/Elfinder/helper/main.js.twig'), 200, [
+                'Content-type' => 'text/javascript',
+            ]);
     }
 }


### PR DESCRIPTION
The MIME type of the javascript should be `text/javascript`
With the `X-Content-Type-Option` sets to `nosniff`, the finder doesn't even load else