### PR TITLE
ADD version option to config for aws_s3_v2

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -361,6 +361,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('key')->defaultvalue('')->end()
                             ->scalarNode('secret')->defaultvalue('')->end()
                             ->scalarNode('region')->defaultvalue('')->end()
+                            ->scalarNode('version')->defaultvalue('2006-03-01')->end()
                             ->scalarNode('bucket_name')->defaultvalue('')->end()
                             ->scalarNode('optional_prefix')->defaultvalue('')->end()
                             ->scalarNode('base_url')->defaultvalue('')->end()


### PR DESCRIPTION
This config option is currently being used in the [ConfigurationReader](https://github.com/helios-ag/FMElfinderBundle/blob/master/src/Configuration/ElFinderConfigurationReader.php#L240), but is not defined in the configuration settings.