### PR TITLE
Improved error message for custom adapter service.

### DIFF
--- a/src/Configuration/ElFinderConfigurationReader.php
+++ b/src/Configuration/ElFinderConfigurationReader.php
@@ -282,6 +282,8 @@ class ElFinderConfigurationReader implements ElFinderConfigurationProviderInterf
                 $adapter = $this->container->get($serviceName);
                 if (is_object($adapter) && $adapter instanceof AdapterInterface) {
                     $filesystem = new Filesystem($adapter);
+                } else {
+                    throw new \Exception(sprintf('Service %s is not an instance of %s.', $serviceName, AdapterInterface::class));
                 }
 
                 break;

--- a/src/Configuration/ElFinderConfigurationReader.php
+++ b/src/Configuration/ElFinderConfigurationReader.php
@@ -174,6 +174,7 @@ class ElFinderConfigurationReader implements ElFinderConfigurationProviderInterf
      */
     private function configureFlysystem($opt, $adapter, $serviceName)
     {
+        $filesystem = null;
         switch ($adapter) {
             case 'local':
                 $filesystem = new Filesystem(new Local($opt['local']['path']));
@@ -280,9 +281,9 @@ class ElFinderConfigurationReader implements ElFinderConfigurationProviderInterf
                 break;
             case 'custom':
                 $adapter = $this->container->get($serviceName);
-                if (is_object($adapter) && $adapter instanceof AdapterInterface) {
+                try {
                     $filesystem = new Filesystem($adapter);
-                } else {
+                } catch (\TypeError $error) {
                     throw new \Exception(sprintf('Service %s is not an instance of %s.', $serviceName, AdapterInterface::class));
                 }
 


### PR DESCRIPTION
Rewrite the flow for the instantiation of a filesystem usinga custom adapter
in such a way that it is possible to include a custom driver.
As well as fixing a notice: undefined variable by declaring `$filesystem = null;`
As well as throwing an exception when a custom adapter was unable to instantiate an instance of `Filesystem`