### PR TITLE
Fix elfinder_tinymce_init4 duplicate definition

### DIFF
--- a/src/Twig/Extension/FMElfinderExtension.php
+++ b/src/Twig/Extension/FMElfinderExtension.php
@@ -30,7 +30,7 @@ class FMElfinderExtension extends AbstractExtension
         return [
             new TwigFunction('elfinder_tinymce_init', [$this, 'tinymce'], $options),
             new TwigFunction('elfinder_tinymce_init4', [$this, 'tinymce4'], $options),
-            new TwigFunction('elfinder_tinymce_init4', [$this, 'tinymce5'], $options),
+            new TwigFunction('elfinder_tinymce_init5', [$this, 'tinymce5'], $options),
             new TwigFunction('elfinder_summernote_init', [$this, 'summernote'], $options),
         ];
     }


### PR DESCRIPTION
There was double elfinder_tinymce_init4 definition which made it impossible to load tinymce4 resource.
