### PR TITLE
fix plugin options not passed

### DIFF
--- a/src/Configuration/ElFinderConfigurationReader.php
+++ b/src/Configuration/ElFinderConfigurationReader.php
@@ -85,7 +85,7 @@ class ElFinderConfigurationReader implements ElFinderConfigurationProviderInterf
                 'service'           => $driver,
                 'glideURL'          => $parameter['glide_url'],
                 'glideKey'          => $parameter['glide_key'],
-                'plugin'            => $parameter['plugins'],
+                'plugin'            => $options['plugins'],
                 'path'              => $pathAndHomeFolder,
                 'startPath'         => $parameter['start_path'],
                 'encoding'          => $parameter['encoding'],

--- a/src/Configuration/ElFinderConfigurationReader.php
+++ b/src/Configuration/ElFinderConfigurationReader.php
@@ -85,7 +85,7 @@ class ElFinderConfigurationReader implements ElFinderConfigurationProviderInterf
                 'service'           => $driver,
                 'glideURL'          => $parameter['glide_url'],
                 'glideKey'          => $parameter['glide_key'],
-                'plugin'            => $options['plugins'],
+                'plugin'            => $options['plugin'],
                 'path'              => $pathAndHomeFolder,
                 'startPath'         => $parameter['start_path'],
                 'encoding'          => $parameter['encoding'],


### PR DESCRIPTION
I've noticed that the plugin options aren't correctly passed.
The function $volume->getOptionsPlugin(...) always returns an empty array.

This PR should fix it.

Affected versions: from 9.3 upwards for sure