### PR TITLE
Fix unnecessary PHP exit

### DIFF
--- a/src/Connector/ElFinderConnector.php
+++ b/src/Connector/ElFinderConnector.php
@@ -11,7 +11,7 @@ class ElFinderConnector extends \elFinderConnector
         if (null === $queryParameters) {
             $queryParameters = $_GET;
         }
-        return json_encode($this->execute($queryParameters)));
+        return json_encode($this->execute($queryParameters));
     }
 
     public function execute($queryParameters)

--- a/src/Connector/ElFinderConnector.php
+++ b/src/Connector/ElFinderConnector.php
@@ -11,7 +11,7 @@ class ElFinderConnector extends \elFinderConnector
         if (null === $queryParameters) {
             $queryParameters = $_GET;
         }
-        exit(json_encode($this->execute($queryParameters)));
+        return json_encode($this->execute($queryParameters)));
     }
 
     public function execute($queryParameters)


### PR DESCRIPTION
<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->

This exit is unnecessarily exiting PHP entirely. Why is this even here?