### PR TITLE
Allow no-credentials for S3 Client

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,7 @@ jobs:
 
       - name: 'Install project dependencies'
         run: |
+          composer global config --no-plugins allow-plugins.symfony/flex true
           composer global require --no-progress --no-scripts --no-plugins symfony/flex
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
           vendor/bin/simple-phpunit install

--- a/src/Configuration/ElFinderConfigurationReader.php
+++ b/src/Configuration/ElFinderConfigurationReader.php
@@ -244,7 +244,7 @@ class ElFinderConfigurationReader implements ElFinderConfigurationProviderInterf
                         'secret' => $opt['aws_s3_v3']['secret'],
                     ];
                 }
-                $client = new S3Client($s3Options);
+                $client     = new S3Client($s3Options);
                 $filesystem = new Filesystem(new AwsS3v3($client, $opt['aws_s3_v3']['bucket_name'], $opt['aws_s3_v3']['optional_prefix'], null, null, $opt['aws_s3_v3']['options']));
 
                 break;

--- a/src/Configuration/ElFinderConfigurationReader.php
+++ b/src/Configuration/ElFinderConfigurationReader.php
@@ -232,16 +232,19 @@ class ElFinderConfigurationReader implements ElFinderConfigurationProviderInterf
 
                 break;
             case 'aws_s3_v3':
-                $client = new S3Client([
-                    'credentials' => [
-                        'key'     => $opt['aws_s3_v3']['key'],
-                        'secret'  => $opt['aws_s3_v3']['secret'],
-                    ],
+                $s3Options = [
                     'region'                  => $opt['aws_s3_v3']['region'],
                     'version'                 => $opt['aws_s3_v3']['version'],
                     'endpoint'                => $opt['aws_s3_v3']['endpoint'],
                     'use_path_style_endpoint' => $opt['aws_s3_v3']['use_path_style_endpoint'],
-                ]);
+                ];
+                if (!empty($opt['aws_s3_v3']['key']) && !empty($opt['aws_s3_v3']['secret'])) {
+                    $s3Options['credentials'] = [
+                        'key'    => $opt['aws_s3_v3']['key'],
+                        'secret' => $opt['aws_s3_v3']['secret'],
+                    ];
+                }
+                $client = new S3Client($s3Options);
                 $filesystem = new Filesystem(new AwsS3v3($client, $opt['aws_s3_v3']['bucket_name'], $opt['aws_s3_v3']['optional_prefix'], null, null, $opt['aws_s3_v3']['options']));
 
                 break;


### PR DESCRIPTION
The S3 Client, from the official AWS SDK, allows instantiating itself without having the credentials specified (this way the credential provider will try to resolve the credentials from environment variables, or try to authenticate - at runtime - the instance based on its profile id).

This PR enables this behavior, for those who wants to use it.

Thank you.