### PR TITLE
Remove framework assets version to be able to work with RequireJs.

### DIFF
--- a/src/Controller/ElFinderController.php
+++ b/src/Controller/ElFinderController.php
@@ -7,6 +7,8 @@ namespace FM\ElfinderBundle\Controller;
 use Exception;
 use FM\ElfinderBundle\Loader\ElFinderLoader;
 use FM\ElfinderBundle\Session\ElFinderSession;
+use Symfony\Component\Asset\Package;
+use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -222,8 +224,11 @@ class ElFinderController
 
     public function mainJS()
     {
+        $version = new EmptyVersionStrategy();
+        $package = new Package($version);
+        $mainUrl = $package->getUrl('bundles/fmelfinder/js');
         return new Response(
-            $this->twig->render('@FMElfinder/Elfinder/helper/main.js.twig'),
+            $this->twig->render('@FMElfinder/Elfinder/helper/main.js.twig',['mainUrl' => $mainUrl]),
             200,
             [
                 'Content-type' => 'text/javascript',

--- a/src/Resources/views/Elfinder/helper/main.js.twig
+++ b/src/Resources/views/Elfinder/helper/main.js.twig
@@ -115,7 +115,7 @@
 
     // config of RequireJS (REQUIRED)
     require.config({
-        baseUrl : "{{ asset('bundles/fmelfinder/js') }}",
+        baseUrl : "{{ mainUrl }}",
         paths : {
             'jquery'   : '//cdnjs.cloudflare.com/ajax/libs/jquery/'+(old? '1.12.4' : jqver)+'/jquery.min',
             'jquery-ui': '//cdnjs.cloudflare.com/ajax/libs/jqueryui/'+uiver+'/jquery-ui.min',


### PR DESCRIPTION
Fix for the issue: **Failed to load ressources with framework.assets.version** #429 

I just added the EmptyVersionStrategy so don't break the RequireJs