### PR TITLE
Fixes #491 - mainUrl was not an absolute path

### DIFF
--- a/src/Controller/ElFinderController.php
+++ b/src/Controller/ElFinderController.php
@@ -226,7 +226,7 @@ class ElFinderController
     {
         $version = new EmptyVersionStrategy();
         $package = new Package($version);
-        $mainUrl = $package->getUrl('bundles/fmelfinder/js');
+        $mainUrl = $package->getUrl('/bundles/fmelfinder/js');
         return new Response(
             $this->twig->render('@FMElfinder/Elfinder/helper/main.js.twig',['mainUrl' => $mainUrl]),
             200,


### PR DESCRIPTION
Following issue #491, in **ElFinderController**, when defining **$mainUrl** at line 229, this is a relative path and not absolute.
To make it absolute, a **/** have been added according to the [Symfony documentation](https://symfony.com/doc/current/components/asset.html#usage).