### PR TITLE
determine the vendor root dir based on the composer classloader

### DIFF
--- a/src/Command/ElFinderInstallerCommand.php
+++ b/src/Command/ElFinderInstallerCommand.php
@@ -61,12 +61,15 @@ EOF
 
         $publicDir = sprintf('%s/%s/bundles/fmelfinder', $rootDir, $dr);
 
+        $reflection = new \ReflectionClass(\Composer\Autoload\ClassLoader::class);
+        $vendorRootDir = dirname($reflection->getFileName(), 3);
+
         $io->note(sprintf('Starting to install elfinder to %s folder', $publicDir));
 
-        $this->fileSystem->mirror($rootDir.'/'.self::ELFINDER_CSS_DIR, $publicDir.'/css');
-        $this->fileSystem->mirror($rootDir.'/'.self::ELFINDER_IMG_DIR, $publicDir.'/img');
-        $this->fileSystem->mirror($rootDir.'/'.self::ELFINDER_JS_DIR, $publicDir.'/js');
-        $this->fileSystem->mirror($rootDir.'/'.self::ELFINDER_SOUNDS_DIR, $publicDir.'/sounds');
+        $this->fileSystem->mirror($vendorRootDir.'/'.self::ELFINDER_CSS_DIR, $publicDir.'/css');
+        $this->fileSystem->mirror($vendorRootDir.'/'.self::ELFINDER_IMG_DIR, $publicDir.'/img');
+        $this->fileSystem->mirror($vendorRootDir.'/'.self::ELFINDER_JS_DIR, $publicDir.'/js');
+        $this->fileSystem->mirror($vendorRootDir.'/'.self::ELFINDER_SOUNDS_DIR, $publicDir.'/sounds');
 
         $io->success('elFinder assets successfully installed');
 

--- a/src/Command/ElFinderInstallerCommand.php
+++ b/src/Command/ElFinderInstallerCommand.php
@@ -47,7 +47,7 @@ You can pass docroot:
   <info>Where to install elfinder</info>
   <info>php %command.full_name% --docroot=public_html</info>
 EOF
-        );
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -61,7 +61,7 @@ EOF
 
         $publicDir = sprintf('%s/%s/bundles/fmelfinder', $rootDir, $dr);
 
-        $reflection = new \ReflectionClass(\Composer\Autoload\ClassLoader::class);
+        $reflection    = new \ReflectionClass(\Composer\Autoload\ClassLoader::class);
         $vendorRootDir = dirname($reflection->getFileName(), 3);
 
         $io->note(sprintf('Starting to install elfinder to %s folder', $publicDir));


### PR DESCRIPTION
<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->

When the `vendor` folder is not in the `%kernel.project_dir%`, the `elfinder:install` command fails:

```
./bin/console elfinder:install

elFinder Installer
==================

 // Trying to install elfinder to public directory

 ! [NOTE] Starting to install elfinder to /var/www/html/docroot/public/bundles/fmelfinder folder


In Filesystem.php line 544:

  The origin directory specified "/var/www/html/docroot/vendor/studio-42/elfinder/css" was not found.

```

This is typically the case when the `vendor` folder is outside of the webroot dir, which is from security point of view a best practice.

This PR ensures the `vendor` folder location is determined based on the composer classloader.
This both works for application with the `vendor` inside and outside the webroot dir.
