### PR TITLE
Correctly fix return of Connector and Loader in non-cors mode

### DIFF
--- a/src/Connector/ElFinderConnector.php
+++ b/src/Connector/ElFinderConnector.php
@@ -11,7 +11,7 @@ class ElFinderConnector extends \elFinderConnector
         if (null === $queryParameters) {
             $queryParameters = $_GET;
         }
-        exit(json_encode($this->execute($queryParameters)));
+        return $this->execute($queryParameters);
     }
 
     public function execute($queryParameters)

--- a/src/Loader/ElFinderLoader.php
+++ b/src/Loader/ElFinderLoader.php
@@ -95,7 +95,7 @@ class ElFinderLoader
         if ($this->config['corsSupport']) {
             return $connector->execute($request->query->all());
         } else {
-            $connector->run($request->query->all());
+            return $connector->run($request->query->all());
         }
     }
 


### PR DESCRIPTION
This should correctly remove the exit, and return the correct response.