### PR TITLE
Add return type to FMElfinderBundle::build()

### DIFF
--- a/src/FMElfinderBundle.php
+++ b/src/FMElfinderBundle.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class FMElfinderBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 


### PR DESCRIPTION
Fixes this warning:

User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "FM\ElfinderBundle\FMElfinderBundle" now to avoid errors or add an explicit @return annotation to suppress this message.