### PR TITLE
Add return type to TwigFormPass::process()

### DIFF
--- a/src/DependencyInjection/Compiler/TwigFormPass.php
+++ b/src/DependencyInjection/Compiler/TwigFormPass.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 
 class TwigFormPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasParameter('twig.form.resources')) {
             return;


### PR DESCRIPTION
This fixes the warning:

Method
"Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation
"FM\ElfinderBundle\DependencyInjection\Compiler\TwigFormPass" now to avoid errors or add an explicit @return annotation to suppress this message.