### PR TITLE
Add return types to ElFinderType

### DIFF
--- a/src/Form/Type/ElFinderType.php
+++ b/src/Form/Type/ElFinderType.php
@@ -13,7 +13,7 @@ class ElFinderType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->setAttribute('enable', $options['enable']);
 
@@ -26,7 +26,7 @@ class ElFinderType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['enable'] = $options['enable'];
 
@@ -39,7 +39,7 @@ class ElFinderType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([


### PR DESCRIPTION
This fixes the below warnings:

Method
"Symfony\Component\Form\AbstractType::buildForm()" might add "void" as a native return type declaration in the future. Do the same in child class
"FM\ElfinderBundle\Form\Type\ElFinderType"
now to avoid errors or add an explicit @return annotation to suppress this message.

Method
"Symfony\Component\Form\AbstractType::buildView()" might add "void" as a native return type declaration in the future. Do the same in child class
"FM\ElfinderBundle\Form\Type\ElFinderType"
now to avoid errors or add an explicit @return annotation to suppress this message.

Method
"Symfony\Component\Form\AbstractType::configureOptions()" might add "void" as a native return type declaration in the future. Do the same in child class
"FM\ElfinderBundle\Form\Type\ElFinderType"
now to avoid errors or add an explicit @return annotation to suppress this message.