### PR TITLE
Add use_aws_shared_config_files option to fm_elfinder configuration

### DIFF
--- a/docs/configuration-dump.md
+++ b/docs/configuration-dump.md
@@ -173,6 +173,7 @@ fm_elfinder:
                                     optional_prefix:      ''
                                     endpoint:             ''
                                     use_path_style_endpoint: false
+                                    use_aws_shared_config_files: true
                                     options:
                                         enabled:              false
                                         ACL:                  ''

--- a/docs/flysystem.md
+++ b/docs/flysystem.md
@@ -107,6 +107,8 @@ Define the variables in your config.yml or set it directly.
 
 If you don't use subdomain that contains your `bucket_name` and want to use your own **endpoint** make sure to set **use_path_style_endpoint** to `true` so that it will format the url correctly.
 
+To prevent AWS PHP SDK from verifying the presence of a shared configuration in .aws/configuration make sure to set **use_aws_shared_config_files**  to `false`.
+
 Also possible to define Flysystem adapters as services, it can be useful for self written adapters.
 To use adapter as service, define it under 'services' node in your services.yml (or use DI)
 

--- a/src/Configuration/ElFinderConfigurationReader.php
+++ b/src/Configuration/ElFinderConfigurationReader.php
@@ -268,10 +268,11 @@ class ElFinderConfigurationReader implements ElFinderConfigurationProviderInterf
                 break;
             case 'aws_s3_v3':
                 $s3Options = [
-                    'region'                  => $opt['aws_s3_v3']['region'],
-                    'version'                 => $opt['aws_s3_v3']['version'],
-                    'endpoint'                => $opt['aws_s3_v3']['endpoint'],
-                    'use_path_style_endpoint' => $opt['aws_s3_v3']['use_path_style_endpoint'],
+                    'region'                      => $opt['aws_s3_v3']['region'],
+                    'version'                     => $opt['aws_s3_v3']['version'],
+                    'endpoint'                    => $opt['aws_s3_v3']['endpoint'],
+                    'use_path_style_endpoint'     => $opt['aws_s3_v3']['use_path_style_endpoint'],
+                    'use_aws_shared_config_files' => $opt['aws_s3_v3']['use_aws_shared_config_files'],
                 ];
 
                 if (!empty($opt['aws_s3_v3']['key']) && !empty($opt['aws_s3_v3']['secret'])) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -391,6 +391,7 @@ final class Configuration implements ConfigurationInterface
                             ->scalarNode('optional_prefix')->defaultvalue('')->end()
                             ->scalarNode('endpoint')->defaultNull()->end()
                             ->booleanNode('use_path_style_endpoint')->defaultFalse()->end()
+                            ->booleanNode('use_aws_shared_config_files')->defaultTrue()->end()
                             ->arrayNode('options')
                                 ->canBeEnabled()
                                     ->children()


### PR DESCRIPTION
Allow option configuration for S3Client : use_aws_shared_config_files
It prevent AWS PHP SDK to check presence of shared configuration file in folder that may be protected (creating an error in path secured environment)
