### PR TITLE
Fix : Use of "self" in callables is deprecated

### DIFF
--- a/src/ElFinder/ElFinder.php
+++ b/src/ElFinder/ElFinder.php
@@ -198,7 +198,7 @@ class ElFinder extends BaseElFinder
                 $doRegist = (false !== strpos($cmd, '*'));
 
                 if (!$doRegist) {
-                    $doRegist = ($_reqCmd && in_array($_reqCmd, array_map('self::getCmdOfBind', explode(' ', $cmd))));
+                    $doRegist = ($_reqCmd && in_array($_reqCmd, array_map('elFinder::getCmdOfBind', explode(' ', $cmd))));
                 }
 
                 if ($doRegist) {


### PR DESCRIPTION
Fixes issue [!531](https://github.com/helios-ag/FMElfinderBundle/issues/531)

Proposed by [dleffler](https://github.com/dleffler) in [Studio-42/elFinder](https://github.com/Studio-42/elFinder/issues/3546)
