### PR TITLE
Fix Typed property must not be accessed before initialization

### DIFF
--- a/src/Loader/ElFinderLoader.php
+++ b/src/Loader/ElFinderLoader.php
@@ -19,7 +19,7 @@ class ElFinderLoader implements ElFinderLoaderInterface
 
     protected ElFinderBridge $bridge;
 
-    protected ?SessionInterface $session;
+    protected ?SessionInterface $session = null;
 
     public function __construct(ElFinderConfigurationProviderInterface $configurator)
     {


### PR DESCRIPTION
Fix "Typed property FM\ElfinderBundle\Loader\ElFinderLoader::$session must not be accessed before initialization" caused by FMElfinderBundle/src/Loader/ElFinderLoader.php:65
