### PR TITLE
Remove E_STRICT

### DIFF
--- a/src/ElFinder/ElFinder.php
+++ b/src/ElFinder/ElFinder.php
@@ -41,7 +41,7 @@ class ElFinder extends BaseElFinder
         $this->version = (string) self::$ApiVersion;
 
         // set error handler of WARNING, NOTICE
-        $errLevel = E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE | E_STRICT | E_RECOVERABLE_ERROR;
+        $errLevel = E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE | E_RECOVERABLE_ERROR;
 
         if (defined('E_DEPRECATED')) {
             $errLevel |= E_DEPRECATED | E_USER_DEPRECATED;


### PR DESCRIPTION
E_STRICT is no longer used by PHP8.0 and newer, but it does emit deprecation notices when using PHP 8.4 (https://php.watch/versions/8.4/E_STRICT-deprecated). As this bundle required PHP ^8.1 it can safely be removed.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss it.

Note: all your contributions adhere implicitly to the MIT license
-->
