### PR TITLE
chore(composer): fix branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "13.0-dev"
+            "dev-main": "13.x-dev"
         }
     },
     "scripts": {


### PR DESCRIPTION
Fix the branch-alias to allow requiring `"helios-ag/fm-elfinder-bundle": "^13.0",` with minimum-stability set to `dev`.